### PR TITLE
Speed up Circle CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,11 +124,6 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - cypress/install: # Use Cypress step to install and cache dependencies
-          cache-key: &cypress-cache-key 'npm-packages-cache1-{{ arch }}-{{ checksum "package-lock.json" }}'
-          post-checkout:
-            - run: cp .env.sample .env
-
       - build
 
       - test:
@@ -136,10 +131,11 @@ workflows:
             - build
 
       - cypress/run:
-          cache-key: *cypress-cache-key
+          cache-key: &cypress-cache-key 'npm-packages-cache1-{{ arch }}-{{ checksum "package-lock.json" }}'
+          post-checkout:
+            - run: cp .env.sample .env
           requires:
             - build
-            - cypress/install
           executor: cypress/base-14
           attach-workspace: true
           start: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,7 @@ workflows:
     jobs:
       - cypress/install: # Use Cypress step to install and cache dependencies
           build: npm run build
+          cache-key: &cypress-cache-key 'npm-packages-cache1-{{ arch }}-{{ checksum "package-lock.json" }}'
           post-checkout:
             - run: cp .env.sample .env
 
@@ -116,6 +117,7 @@ workflows:
             - cypress/install
 
       - cypress/run:
+          cache-key: *cypress-cache-key
           requires:
             - cypress/install
           executor: cypress/base-14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,15 +134,13 @@ workflows:
           cache-key: &cypress-cache-key 'npm-packages-cache1-{{ arch }}-{{ checksum "package-lock.json" }}'
           post-checkout:
             - run: cp .env.sample .env
-          requires:
-            - build
           executor: cypress/base-14
-          attach-workspace: true
           start: |
             npm install cypress-dotenv -g
             npm run dev
           wait-on: 'http-get://127.0.0.1:3000'
           store_artifacts: true
+          no-workspace: true
 
       - assume-role-staging:
           context: api-assume-role-staging-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,30 @@ commands:
             sls deploy -s <<parameters.stage>>
 
 jobs:
+  build:
+    executor: node
+    steps:
+      - *attach_workspace
+      - checkout
+      - restore_cache:
+          key: &build-cache-key 'next-build-cache3-{{ arch }}-{{ checksum "package-lock.json" }}'
+      - run: CYPRESS_INSTALL_BINARY=0 npm ci
+      - run: npm run build
+      - save_cache:
+          key: *build-cache-key
+          paths:
+            - ./node_modules
+            - ./build/_next
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - project
+
   test:
     executor: node
 
     steps:
       - *attach_workspace
-      - checkout
-      - run: npm ci
       - run:
           name: Run unit tests
           command: npm run test
@@ -108,18 +125,20 @@ workflows:
   continuous-delivery:
     jobs:
       - cypress/install: # Use Cypress step to install and cache dependencies
-          build: npm run build
           cache-key: &cypress-cache-key 'npm-packages-cache1-{{ arch }}-{{ checksum "package-lock.json" }}'
           post-checkout:
             - run: cp .env.sample .env
 
+      - build
+
       - test:
           requires:
-            - cypress/install
+            - build
 
       - cypress/run:
           cache-key: *cypress-cache-key
           requires:
+            - build
             - cypress/install
           executor: cypress/base-14
           attach-workspace: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ references:
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
+  build_cache_key: &build-cache-key 'next-build-cache3-{{ arch }}-{{ checksum "package-lock.json" }}'
 
 commands:
   assume-role-and-persist-workspace:
@@ -57,7 +58,7 @@ jobs:
       - *attach_workspace
       - checkout
       - restore_cache:
-          key: &build-cache-key 'next-build-cache3-{{ arch }}-{{ checksum "package-lock.json" }}'
+          key: *build-cache-key
       - run: CYPRESS_INSTALL_BINARY=0 npm ci
       - run: npm run build
       - save_cache:
@@ -106,6 +107,8 @@ jobs:
     steps:
       - *attach_workspace
       - checkout
+      - restore_cache:
+          key: *build-cache-key
 
       - deploy-lambda:
           stage: staging
@@ -116,6 +119,8 @@ jobs:
     steps:
       - *attach_workspace
       - checkout
+      - restore_cache:
+          key: *build-cache-key
 
       - deploy-lambda:
           stage: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,18 +57,19 @@ jobs:
     steps:
       - *attach_workspace
       - checkout
+      - run: npm ci
+      - run:
+          name: Run unit tests
+          command: npm run test
 
-#      - run:
-#          name: Run linter
-#          command: npm run lint
+  #      - run:
+  #          name: Run linter
+  #          command: npm run lint
 
-#      - run:
-#          name: Run prettier
-#          command: npm run prettier:test
+  #      - run:
+  #          name: Run prettier
+  #          command: npm run prettier:test
 
-#      - run:
-#          name: Run unit tests
-#          command: npm run test:unit -- --maxWorkers=2
 
   assume-role-staging:
     executor: python

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:3000"
+  "baseUrl": "http://localhost:3000",
+  "videoUploadOnPasses": false
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    testPathIgnorePatterns: ["<rootDir>/.next/","<rootDir>/cypress/", "<rootDir>/node_modules/"],
+    testPathIgnorePatterns: ["<rootDir>/.next/","<rootDir>/build/_next","<rootDir>/cypress/", "<rootDir>/node_modules/"],
     setupFilesAfterEnv: ["<rootDir>/setupTests.js"],
     transform: {
       "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",


### PR DESCRIPTION
There were a few efficiencies we could add in:

* Maintain the nextjs build cache between runs including deployment
* Maintain the node_modules between runs
* Maintain the cypress cache between runs
* Reduce the cypress steps into one to remove the need to store and restore the workspace.
* Don't record videos from passed cypress tests

Also added the jest test run to cover any unit tests

Time down from about 4m30 to 2m30ish