### PR TITLE
Avoid PATCH request to API proxy, add patch as a query param for proxy

### DIFF
--- a/src/gateways/default-gateway.js
+++ b/src/gateways/default-gateway.js
@@ -45,7 +45,8 @@ export class DefaultGateway {
 
     async patchToUrl(url, body) {
       parseCamelToPascalCase(body);
-      const res = await axios.patch(this.createFullUrl(url), body, {
+      //Make patches do a post, but add method=patch in the URL
+      const res = await axios.put(this.createFullUrl(url)+"?method=patch", body, {
           headers: {
               'Content-Type': 'application/json'
           }

--- a/src/pages/api/proxy/[...path].js
+++ b/src/pages/api/proxy/[...path].js
@@ -9,6 +9,9 @@ const endpoint = async (req, res) => {
 
     const path = req.query.path;
 
+    // Allow a URL parameter to switch request method, as PATCH doens't play well with Lambda Next
+    if(req.url.indexOf('?method=patch')!==-1) req.method = 'PATCH';
+
     try {
         
        const queryParams = Object.keys(req.query).reduce((object, key) => {

--- a/src/pages/api/proxy/[...path].test.js
+++ b/src/pages/api/proxy/[...path].test.js
@@ -13,7 +13,8 @@ const mockedAuthoriseUser = authoriseUser;
 describe('endpoint', () => {
     const req = ({
         method: 'GET',
-        query: { path: ['foo'] }
+        query: { path: ['foo'] },
+        url: ""
     });
 
     const res = ({


### PR DESCRIPTION
Bug in frontend whereby on staging, you cannot PATCH to the API proxy, it throws a 415.