### PR TITLE
Fix saving calls

### DIFF
--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -28,14 +28,32 @@ export default function CallbackForm({residentId, resident, backHref, saveFuncti
     const [errorsExist, setErrorsExist] = useState(null)
 
     const spokeToResidentCallOutcomes = [
-        "Callback complete",
-        "Refused to engage",
-        "Call rescheduled",
+        {
+            label: "Callback complete",
+            value: "callback_complete"
+        },
+        {
+            label: "Refused to engage",
+            value: "refused_to_engage"
+        },
+        {
+            label: "Call rescheduled",
+            value: "call_rescheduled"
+        }
     ];
     const noAnswerCallOutcomes = [
-        "Voicemail left",
-        "Wrong number",
-        "No answer machine",
+        {
+            label: "Voicemail left",
+            value: "voicemail"
+        },
+        {
+            label: "Wrong number",
+            value: "wrong_number"
+        },
+        {
+            label: "No answer machine",
+            value: "no_answer_machine"
+        }
     ];
     const callTypes = [
         "Contact Tracing",
@@ -218,11 +236,11 @@ export default function CallbackForm({residentId, resident, backHref, saveFuncti
                                                                     {spokeToResidentCallOutcomes.map((spokeToResidentCallOutcome) => {
                                                                         return (
                                                                             <Checkbox
-                                                                                id={spokeToResidentCallOutcome}
+                                                                                id={spokeToResidentCallOutcome.value}
                                                                                 name="spokeToResidentCallOutcome"
                                                                                 type="checkbox"
-                                                                                value={spokeToResidentCallOutcome}
-                                                                                label={spokeToResidentCallOutcome}
+                                                                                value={spokeToResidentCallOutcome.value}
+                                                                                label={spokeToResidentCallOutcome.label}
                                                                                 aria-describedby="CallOutcome-hint"
                                                                                 onCheckboxChange={onCheckboxChangeUpdate}>
                                                                             </Checkbox>
@@ -257,14 +275,13 @@ export default function CallbackForm({residentId, resident, backHref, saveFuncti
                                                                 {noAnswerCallOutcomes.map((noAnswerCallOutcome) => {
                                                                     return (
                                                                         <Checkbox
-                                                                            id={noAnswerCallOutcome}
+                                                                            id={noAnswerCallOutcome.value}
                                                                             name="noAnswerCallOutcome"
                                                                             type="checkbox"
-                                                                            value={noAnswerCallOutcome}
-                                                                            label={noAnswerCallOutcome}
+                                                                            value={noAnswerCallOutcome.value}
+                                                                            label={noAnswerCallOutcome.label}
                                                                             onCheckboxChange={onCheckboxChangeUpdate}
                                                                             aria-describedby="CallOutcome-hint">
-
                                                                         </Checkbox>
                                                                     );
                                                                 })}

--- a/src/gateways/help-request-call.js
+++ b/src/gateways/help-request-call.js
@@ -5,7 +5,7 @@ const ToPostHelpRequestCall = (hr) => {
   return JSON.stringify({
       CallType: (hr.callType == CEV) ? SHIELDING: hr.callType,
 			CallDirection: hr.callDirection,
-			CallOutcome: hr.callOutcomeValues,
+			CallOutcome: hr.callOutcome,
 			CallDateTime: hr.callDateTime,
 			CallHandler: hr.callHandler
   })

--- a/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
+++ b/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
@@ -31,11 +31,11 @@ export default function addSupportPage({residentId, helpRequestId}) {
 
     const saveFunction = async function(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade) {
         let callRequestObject = {
-            CallType: helpNeeded,
-            CallDirection: callDirection,
-            CallOutcome: callOutcomeValues,
-            CallDateTime: new Date(),
-            CallHandler: user.name
+            callType: helpNeeded,
+            callDirection: callDirection,
+            callOutcome: callOutcomeValues,
+            callDateTime: new Date(),
+            callHandler: user.name
         }
 
         try{
@@ -48,7 +48,7 @@ export default function addSupportPage({residentId, helpRequestId}) {
 
             if(callMade) {
                 let helpRequestCallGateway = new HelpRequestCallGateway();
-                let helpRequestCallId = await helpRequestCallGateway.postHelpRequestCall(helpRequestId, JSON.stringify(callRequestObject));
+                let helpRequestCallId = await helpRequestCallGateway.postHelpRequestCall(helpRequestId, callRequestObject);
             }
 
             router.push(`/helpcase-profile/${residentId}`)


### PR DESCRIPTION
Change casing for call object keys in manage-request page
Rename CallOutcomeValues to callOutcome 
Change the values for call outcomes to be stored the way we're storing and checking it currently (not sure if we want to keep it that way)

This should fix the issue of setting call values to defaults/undefined
Should also fix this issue
https://trello.com/c/SmseTCHw/34-bug-callback-list-page-does-not-display-the-correct-number-of-unsuccessful-call-attempts