### PR TITLE
Call history

### DIFF
--- a/cypress/fixtures/callbacks.json
+++ b/cypress/fixtures/callbacks.json
@@ -318,7 +318,7 @@
                 "HelpRequestId": 65,
                 "CallType": "Help Request",
                 "CallDirection": "inbound",
-                "CallOutcome": "follow_up_requested",
+                "CallOutcome": "callback_complete",
                 "CallDateTime": "2021-01-09T14:31:02.589Z"
             }
         ]

--- a/cypress/fixtures/residents/3/helpRequests.json
+++ b/cypress/fixtures/residents/3/helpRequests.json
@@ -46,7 +46,8 @@
                 "HelpRequestId": 11,
                 "CallType": "Contact Tracing",
                 "CallDirection": "inbound",
-                "CallOutcome": "follow_up_requested",
+                "CallOutcome": "callback_complete",
+                "CallHandler": "Bart Simpson",
                 "CallDateTime": "2021-01-18T08:22:31.274Z"
             },
             {
@@ -54,7 +55,8 @@
                 "HelpRequestId": 11,
                 "CallType": "Contact Tracing",
                 "CallDirection": "inbound",
-                "CallOutcome": "follow_up_requested",
+                "CallOutcome": "callback_complete",
+                "CallHandler": "Bart Simpson",
                 "CallDateTime": "2021-01-23T18:16:35.195Z"
             }
         ]
@@ -106,16 +108,9 @@
                 "HelpRequestId": 12,
                 "CallType": "Welfare",
                 "CallDirection": "outbound",
-                "CallOutcome": "follow_up_requested",
+                "CallOutcome": "wrong_number",
+                "CallHandler": "Bart Simpson",
                 "CallDateTime": "2021-01-26T15:12:25.562Z"
-            },
-            {
-                "Id": 24,
-                "HelpRequestId": 12,
-                "CallType": "Shielding",
-                "CallDirection": "outbound",
-                "CallOutcome": "follow_up_requested",
-                "CallDateTime": "2021-01-11T08:04:28.136Z"
             }
         ]
     },
@@ -166,7 +161,8 @@
                 "HelpRequestId": 13,
                 "CallType": "Welfare",
                 "CallDirection": "inbound",
-                "CallOutcome": "wrong_numbercallback_complete",
+                "CallOutcome": "wrong_number,callback_complete",
+                "CallHandler": "Homer Simpson",
                 "CallDateTime": "2020-12-23T06:51:24.613Z"
             },
             {
@@ -175,6 +171,7 @@
                 "CallType": "Welfare",
                 "CallDirection": "outbound",
                 "CallOutcome": "wrong_number",
+                "CallHandler": "Bart Simpson",
                 "CallDateTime": "2021-01-04T23:26:15.066Z"
             }
         ]
@@ -220,24 +217,7 @@
         "WhenIsMedicinesDelivered": "",
         "RescheduledAt": "",
         "RequestedDate": "2021-01-30T10:23:55.751Z",
-        "HelpRequestCalls": [
-            {
-                "Id": 27,
-                "HelpRequestId": 14,
-                "CallType": "Shielding",
-                "CallDirection": "inbound",
-                "CallOutcome": "wrong_number",
-                "CallDateTime": "2021-01-18T20:48:40.253Z"
-            },
-            {
-                "Id": 28,
-                "HelpRequestId": 14,
-                "CallType": "Shielding",
-                "CallDirection": "outbound",
-                "CallOutcome": "wrong_numbercallback_complete",
-                "CallDateTime": "2021-01-05T09:52:55.258Z"
-            }
-        ]
+        "HelpRequestCalls": []
     },
     {
         "Id": 15,
@@ -286,7 +266,8 @@
                 "HelpRequestId": 15,
                 "CallType": "Help Request",
                 "CallDirection": "inbound",
-                "CallOutcome": "follow_up_requested",
+                "CallOutcome": "callback_complete",
+                "CallHandler": "Lisa Simpson",
                 "CallDateTime": "2021-01-07T01:26:00.007Z"
             },
             {
@@ -294,7 +275,8 @@
                 "HelpRequestId": 15,
                 "CallType": "Contact Tracing",
                 "CallDirection": "outbound",
-                "CallOutcome": "follow_up_requested",
+                "CallOutcome": "callback_complete",
+                "CallHandler": "Lisa Simpson",
                 "CallDateTime": "2021-01-15T11:32:17.750Z"
             }
         ]

--- a/cypress/fixtures/residents/3/helpRequests/12.json
+++ b/cypress/fixtures/residents/3/helpRequests/12.json
@@ -45,7 +45,7 @@
             "HelpRequestId": 12,
             "CallType": "Welfare",
             "CallDirection": "outbound",
-            "CallOutcome": "follow_up_requested",
+            "CallOutcome": "callback_complete",
             "CallDateTime": "2021-01-26T15:12:25.562Z"
         },
         {
@@ -53,7 +53,7 @@
             "HelpRequestId": 12,
             "CallType": "Shielding",
             "CallDirection": "outbound",
-            "CallOutcome": "follow_up_requested",
+            "CallOutcome": "callback_complete",
             "CallDateTime": "2021-01-11T08:04:28.136Z"
         }
     ]

--- a/cypress/integration/pages/helpcase-profile.spec.js
+++ b/cypress/integration/pages/helpcase-profile.spec.js
@@ -26,6 +26,12 @@ describe('View helpcase profile page', () => {
         cy.get('[data-testid=support-requested-table_row]').should('have.length', 5);
         cy.get('[data-testid=support-requested-table-help-needed]').first().should('contain', "Help Request");
         cy.get('[data-testid=support-requested-table-calls-count]').first().should('contain', "2");
+    });
 
+    it('displays a call history', () => {
+        cy.visit(`http://localhost:3000/helpcase-profile/3`);
+        cy.get('[data-testid=call-history-entry]').should('have.length', 7);
+        cy.get('[data-testid=call-history-entry]').first().should('contain', "2021-01-26 15:12 by Bart Simpson");
+        cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Welfare: Wrong number");
     });
 });

--- a/src/components/CallHistory/CallHistory.jsx
+++ b/src/components/CallHistory/CallHistory.jsx
@@ -1,0 +1,42 @@
+import moment from 'moment';
+import styles from './CallHistory.module.scss';
+
+export default function CaseNotes({ calls }) {
+    const FormatCallOutcome = (outcome) => {
+        if (!outcome) return null;
+        return outcome
+            .replace('callback_complete', 'Callback complete')
+            .replace('refused_to_engage', 'Refused to engage')
+            .replace('call_rescheduled', 'Call rescheduled')
+            .replace('voicemail', 'Voicemail left')
+            .replace('wrong_number', 'Wrong number')
+            .replace('no_answer_machine', 'No answer machine');
+    };
+
+    return (
+        <div>
+            <h2 className="govuk-heading-l">Call history</h2>
+            {calls?.map((call, index) => {
+                return (
+                    <>
+                        <div
+                            key={index}
+                            className={styles['call-history-box']}
+                            id={`call-note-${call.id}`}
+                            data-testid="call-history-entry">
+                            <h4 className="govuk-heading-s">
+                                {moment(call.callDateTime).format('YYYY-MM-DD HH:mm')} by{' '}
+                                {call.callHandler}
+                            </h4>
+                            <p>
+                                {call.callDirection} {call.callType}:{' '}
+                                {FormatCallOutcome(call.callOutcome)}
+                            </p>
+                        </div>
+                        <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+                    </>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/components/CallHistory/CallHistory.module.scss
+++ b/src/components/CallHistory/CallHistory.module.scss
@@ -1,0 +1,5 @@
+.call-history-box {
+    background-color: #dce9d5;
+    padding: 20px;
+    margin-top: 20px;
+}

--- a/src/gateways/help-request.js
+++ b/src/gateways/help-request.js
@@ -55,7 +55,8 @@ const ToCalls = (calls) => {
             callType: call.CallType,
             callDirection: call.CallDirection,
             callOutcome: call.CallOutcome,
-            callDateTime: call.CallDateTime
+            callDateTime: call.CallDateTime,
+            callHandler: call.CallHandler
         };
     });
 };

--- a/src/pages/helpcase-profile/[residentId]/index.js
+++ b/src/pages/helpcase-profile/[residentId]/index.js
@@ -7,6 +7,7 @@ import { Button } from '../../../components/Form';
 import { useRouter } from 'next/router';
 import { ResidentGateway } from '../../../gateways/resident';
 import { HelpRequestGateway } from '../../../gateways/help-request';
+import CallHistory from '../../../components/CallHistory/CallHistory';
 import { useState, useEffect } from 'react';
 export default function HelpcaseProfile({ residentId }) {
     const [resident, setResident] = useState([]);
@@ -28,6 +29,10 @@ export default function HelpcaseProfile({ residentId }) {
         }
     };
     useEffect(getResidentAndHelpRequests, []);
+
+    const calls = [].concat
+        .apply([], helpRequests.map(helpRequest => helpRequest.helpRequestCalls))
+        .sort((a,b) => new Date(b.callDateTime) - new Date(a.callDateTime))
 
     return (
         resident && (
@@ -64,6 +69,7 @@ export default function HelpcaseProfile({ residentId }) {
                             <hr />
 
                             <br />
+                            <CallHistory calls={calls}  />
                             {/* <CaseNotes caseNotes={caseNotes} /> */}
                         </div>
                     </div>


### PR DESCRIPTION
Add call history component and display it on the resident page

<img width="573" alt="image" src="https://user-images.githubusercontent.com/54268893/106270979-b206c700-6226-11eb-912b-f0ef63cc36bc.png">

Update mock data:
 - We do not seem to be using follow up requested as part of the call outcomes anymore, replaced with callback complete
 - Add call handlers to the calls
 
Add mapping for call handlers in the HelpRequest gateway
https://trello.com/c/TKgktpPN/35-as-a-call-handler-i-need-to-be-able-to-see-call-history-for-each-resident-in-the-here-to-help-tool