### PR TITLE
Fix welfare call filtering bug and method name

### DIFF
--- a/cypress/fixtures/callbacks.json
+++ b/cypress/fixtures/callbacks.json
@@ -65,7 +65,7 @@
             {
                 "id": 23,
                 "HelpRequestId": 12,
-                "CallType": "Welfare",
+                "CallType": "Welfare Call",
                 "CallDirection": "outbound",
                 "CallOutcome": "refused_to_engage",
                 "CallDateTime": "2020-12-23T02:50:50.807Z"
@@ -73,7 +73,7 @@
             {
                 "id": 24,
                 "HelpRequestId": 12,
-                "CallType": "Welfare",
+                "CallType": "Welfare Call",
                 "CallDirection": "outbound",
                 "CallOutcome": "refused_to_engage",
                 "CallDateTime": "2021-01-15T11:18:31.236Z"
@@ -380,7 +380,7 @@
         "CallbackRequired": null,
         "CaseNotes": "[object Object]---[object Object]",
         "AdviceNotes": "string",
-        "HelpNeeded": "Welfare",
+        "HelpNeeded": "Welfare Call",
         "NhsNumber": "string",
         "NhsCtasId": "string",
         "AssignedTo": "Person D",
@@ -470,7 +470,7 @@
             {
                 "id": 283,
                 "HelpRequestId": 142,
-                "CallType": "Welfare",
+                "CallType": "Welfare Call",
                 "CallDirection": "inbound",
                 "CallOutcome": "refused_to_engage",
                 "CallDateTime": "2021-01-19T19:19:28.162Z"
@@ -478,7 +478,7 @@
             {
                 "id": 284,
                 "HelpRequestId": 142,
-                "CallType": "Welfare",
+                "CallType": "Welfare Call",
                 "CallDirection": "outbound",
                 "CallOutcome": "refused_to_engagecallback_complete",
                 "CallDateTime": "2021-01-02T17:20:48.848Z"

--- a/cypress/fixtures/residents/3/helpRequests.json
+++ b/cypress/fixtures/residents/3/helpRequests.json
@@ -106,7 +106,7 @@
             {
                 "Id": 23,
                 "HelpRequestId": 12,
-                "CallType": "Welfare",
+                "CallType": "Welfare Call",
                 "CallDirection": "outbound",
                 "CallOutcome": "wrong_number",
                 "CallHandler": "Bart Simpson",
@@ -159,7 +159,7 @@
             {
                 "Id": 25,
                 "HelpRequestId": 13,
-                "CallType": "Welfare",
+                "CallType": "Welfare Call",
                 "CallDirection": "inbound",
                 "CallOutcome": "wrong_number,callback_complete",
                 "CallHandler": "Homer Simpson",
@@ -168,7 +168,7 @@
             {
                 "Id": 26,
                 "HelpRequestId": 13,
-                "CallType": "Welfare",
+                "CallType": "Welfare Call",
                 "CallDirection": "outbound",
                 "CallOutcome": "wrong_number",
                 "CallHandler": "Bart Simpson",
@@ -186,7 +186,7 @@
         "CurrentSupportFeedback": "laboriosam omnis eius velit et",
         "DateTimeRecorded": "2021-01-07T04:45:58.379Z",
         "GettingInTouchReason": "est dolor dolores",
-        "HelpNeeded": "Welfare",
+        "HelpNeeded": "Welfare Call",
         "HelpWithAccessingFood": false,
         "HelpWithAccessingInternet": null,
         "HelpWithAccessingMedicine": false,

--- a/cypress/fixtures/residents/3/helpRequests/12.json
+++ b/cypress/fixtures/residents/3/helpRequests/12.json
@@ -43,7 +43,7 @@
         {
             "Id": 23,
             "HelpRequestId": 12,
-            "CallType": "Welfare",
+            "CallType": "Welfare Call",
             "CallDirection": "outbound",
             "CallOutcome": "callback_complete",
             "CallDateTime": "2021-01-26T15:12:25.562Z"

--- a/cypress/integration/pages/callbacks-list.spec.js
+++ b/cypress/integration/pages/callbacks-list.spec.js
@@ -36,7 +36,7 @@ describe('Callbacks list page filters callbacks correctly', () => {
     it('Upon selecting Help Case Type dropdown value, callbacks get filtered by that value', () => {
         cy.visit('/callback-list');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '6');
-        cy.get('[data-testid=help-type-dropdown]').select('Welfare');
+        cy.get('[data-testid=help-type-dropdown]').select('Welfare Call');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
         cy.get('[data-testid=help-type-dropdown]').select('Help Request');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '3');

--- a/cypress/integration/pages/helpcase-profile.spec.js
+++ b/cypress/integration/pages/helpcase-profile.spec.js
@@ -29,7 +29,7 @@ describe('View helpcase profile page', () => {
 
         cy.get('[data-testid=support-received-tab]').click({force: true})
         cy.get('[data-testid=support-received-table_row]').should('have.length', 1);
-        cy.get('[data-testid=support-received-table-help-needed]').first().should('contain', "Welfare");
+        cy.get('[data-testid=support-received-table-help-needed]').first().should('contain', "Welfare Call");
         cy.get('[data-testid=support-received-table-calls-count]').first().should('contain', "1");
     });
 
@@ -37,6 +37,6 @@ describe('View helpcase profile page', () => {
         cy.visit(`http://localhost:3000/helpcase-profile/3`);
         cy.get('[data-testid=call-history-entry]').should('have.length', 9);
         cy.get('[data-testid=call-history-entry]').first().should('contain', "2021-01-26 15:12 by Bart Simpson");
-        cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Welfare: Wrong number");
+        cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Welfare Call: Wrong number");
     });
 });

--- a/src/components/SupportTable/SupportTable.jsx
+++ b/src/components/SupportTable/SupportTable.jsx
@@ -34,7 +34,7 @@ export default function SupportTable({helpRequests}) {
 								if(hr.callbackRequired == true){
 									return (	<tr className="govuk-table__row" data-testid="support-requested-table_row">
 									<td className="govuk-table__cell" data-testid="support-requested-table-help-needed">{hr.helpNeeded}</td>
-									<td className="govuk-table__cell">{hr.latestCallOutcome}</td>
+									<td className="govuk-table__cell">{hr.upcomingCallOutcome}</td>
 									<td className="govuk-table__cell" data-testid="support-requested-table-calls-count">{hr.helpRequestCalls?.length}</td>
 									<td className="govuk-table__cell" data-testid={`support-requested-table-view_link-${index}`}><Link
 												href="/helpcase-profile/[resident_id]/manage-request/[help_request]"

--- a/src/gateways/call-types.js
+++ b/src/gateways/call-types.js
@@ -6,7 +6,7 @@ export class CallTypesGateway extends DefaultGateway {
             "All",
             "Help Request",
             "CEV",
-            "Welfare",
+            "Welfare Call",
             "Contact Tracing",
         ];
     }

--- a/src/gateways/help-request.js
+++ b/src/gateways/help-request.js
@@ -1,6 +1,6 @@
 import { DefaultGateway } from '../gateways/default-gateway';
 import {CEV, SHIELDING, callOutcomes} from '../helpers/constants';
-const TolatestCallOutcome = (helpRequestCalls, callbackRequired, initialCallbackCompleted) => {
+const ToUpcomingAction = (helpRequestCalls, callbackRequired, initialCallbackCompleted) => {
     let latestCallOutcomes
     let latestCallOutcomesArray = []
     if (callbackRequired == false && initialCallbackCompleted == true){
@@ -67,7 +67,7 @@ const ToHelpRequestDomain = (hr) => {
         rescheduledAt: hr.RescheduledAt,
         requestedDate: hr.RequestedDate,
         helpRequestCalls: ToCalls(hr.HelpRequestCalls),
-        latestCallOutcome:TolatestCallOutcome(hr.HelpRequestCalls, hr.CallbackRequired, hr.InitialCallbackCompleted)
+        upcomingCallOutcome:ToUpcomingAction(hr.HelpRequestCalls, hr.CallbackRequired, hr.InitialCallbackCompleted)
     };
 };
 

--- a/src/pages/assign-calls.js
+++ b/src/pages/assign-calls.js
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useState } from 'react';
 import { Button, Checkbox, Dropdown } from "../components/Form";
 
-const callTypes = ["All", "Help Request", "CEV", "Welfare", "Shielding"];
+const callTypes = ["All", "Help Request", "CEV", "Welfare Call", "Shielding"];
 const callHandlers = ["Annalyvia", "Ryan", "Ben", "Liudvikas", "Kat", "Marten", "John"]
 
 export default function AssignCallsPage() {

--- a/src/pages/callback-list.js
+++ b/src/pages/callback-list.js
@@ -33,6 +33,7 @@ function CallbacksListPage({ callTypes }) {
     };
 
     const handleCallTypeChange = (event) => {
+        console.log(callTypes)
         setDropdowns({ ...dropdowns, callType: event });
     };
 


### PR DESCRIPTION
**What?**
- Fix name of welfare call help request type
- refactor method name in help request gateway to reflect behaviour

**Why**
- Allow contact tracers to filter by welfare call type