### PR TITLE
Parse non json case notes

### DIFF
--- a/cypress/fixtures/residents/3/helpRequests.json
+++ b/cypress/fixtures/residents/3/helpRequests.json
@@ -94,7 +94,7 @@
         "WhenIsMedicinesDelivered": "",
         "RescheduledAt": "04:40",
         "RequestedDate": "2021-02-03T05:09:47.123Z",
-        "CaseNotes": "[{\"author\":\"Professor Umbridge\",\"noteDate\":\"Thu, 10 Sep 2020 16:56:06 GMT\",\"note\":\"*** CREATED ***\"}]",
+        "CaseNotes": "Professor Umbridge : Thu, 10 Sep 2020 08:53:18 GMT ------------ *** CREATED *** ------ ",
         "NhsCtasId": "123abc",
         "HelpRequestCalls": [
             {

--- a/cypress/integration/pages/helpcase-profile.spec.js
+++ b/cypress/integration/pages/helpcase-profile.spec.js
@@ -39,13 +39,14 @@ describe('View helpcase profile page', () => {
         cy.get('[data-testid=call-history-entry]').first().should('contain', "2021-01-26 15:12 by Bart Simpson");
         cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Welfare Call: Wrong number");
     });
-    it.only('displays case notes ordered by date', () => {
+    it('displays JSON and string case notes ordered by date', () => {
         cy.visit(`http://localhost:3000/helpcase-profile/3`);
         cy.get('[data-testid=case-note-entry]').should('have.length', 4);
         cy.get('[data-testid=case-note-entry]').first().scrollIntoView()
         cy.get('[data-testid=case-note-entry]').first().should('contain', "by Professor Umbridge");
         cy.get('[data-testid=case-note-entry]').first().should('contain', "2020-09-10");
-        cy.get('[data-testid=case-note-entry]').first().should('contain', "Help Request: *** CREATED ***");
+        cy.get('[data-testid=case-note-entry]').first().should('contain', "Help Request:");
+        cy.get('[data-testid=case-note-entry]').first().should('contain', "CREATED");
         cy.get('[data-testid=case-note-entry]').last().should('contain', "by Ronald Weasley");
         cy.get('[data-testid=case-note-entry]').last().should('contain', "2020-09-06");
         cy.get('[data-testid=case-note-entry]').last().should('contain', "Welfare Call: *** CREATED ***");

--- a/src/components/CaseNotes/CaseNotes.jsx
+++ b/src/components/CaseNotes/CaseNotes.jsx
@@ -8,7 +8,6 @@ export default function CaseNotes({ caseNotes }) {
     const hanleOnChange = (selectedCaseNoteType) => {
         setFilterBy(selectedCaseNoteType)
     }
-    console.log(caseNotes["All"].length > 0)
     return (
         <div>
             <h2 className="govuk-heading-l">Case notes</h2>

--- a/src/helpers/case_notes_helper.js
+++ b/src/helpers/case_notes_helper.js
@@ -23,3 +23,19 @@ export const formatDate = (date) => {
 
   return [year, month, day].join('-') + time;
 }
+
+export const getAuthor = (text) => {
+  return text.slice(0 ,text.indexOf(" : "))
+}
+
+export const getDate = (text) => {
+  return text.slice(text.indexOf(" : ") + 3, text.indexOf("GMT"))
+}
+
+export const getNote = (text) => {
+  return text.slice(text.indexOf("GMT") + 16)
+}
+export const getNonJsonCasenotesArray = (text) =>{
+  let separators = ["------\r\n\r\n\r\n", "------\n\n\n"];
+  return text.split(new RegExp(separators.join("|"), "g"));
+}


### PR DESCRIPTION
**What**
- Parse case notes stored as strings and display in the same format as the JSON case notes

**Why**
- Old case notes were stored in string format and therefore were not being parsed and displayed with the newly formatted case notes, therefore this work was required to parse though case notes stored as strings

**Ticket**
https://trello.com/c/88Pa6dUx/60-parse-case-notes-stored-in-old-non-json-format

**Screenshot**

![image](https://user-images.githubusercontent.com/46002877/106875624-c89d9a00-66ce-11eb-901e-8443c4fd6178.png)
