### PR TITLE
Add Case notes to manage profile

### DIFF
--- a/cypress/fixtures/residents/3/helpRequests/12.json
+++ b/cypress/fixtures/residents/3/helpRequests/12.json
@@ -40,6 +40,7 @@
     "RescheduledAt": "05:24",
     "RequestedDate": "2021-01-30T05:15:50.027Z",
     "NhsCtasId": "123abc",
+    "CaseNotes": "Professor Umbridge : Thu, 10 Sep 2020 08:53:18 GMT ------------ *** CREATED *** ------ ",
     "HelpRequestCalls": [
         {
             "Id": 23,

--- a/cypress/integration/journeys/manage-a-help-request.spec.js
+++ b/cypress/integration/journeys/manage-a-help-request.spec.js
@@ -24,6 +24,16 @@ context('When you view a helpcase profile', () => {
         cy.get('[data-testid=call-history-entry]').first().should('contain', "2021-01-26 15:12 by handler");
         cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Welfare Call: Callback complete");
     });
+    it.only('it displays the case notes', () => {
+        cy.url().should('match', /\/helpcase-profile\/\d+$/);
+        cy.get('[data-testid=support-requested-table-view_link-0]')
+            .contains('View')
+            .click({ force: true });
+        cy.get('[data-testid=case-note-entry]').should('have.length', 1);
+        cy.get('[data-testid=case-note-entry]').first().should('contain', "020-09-10 08:53 by Professor Umbridge");
+        cy.get('[data-testid=case-note-entry]').first().should('contain', "Contact Tracing:");
+        cy.get('[data-testid=case-note-entry]').first().should('contain', "CREATED");
+    });
 });
 
 context('When required fields are not filled in', () => {

--- a/cypress/integration/journeys/manage-a-help-request.spec.js
+++ b/cypress/integration/journeys/manage-a-help-request.spec.js
@@ -24,7 +24,7 @@ context('When you view a helpcase profile', () => {
         cy.get('[data-testid=call-history-entry]').first().should('contain', "2021-01-26 15:12 by handler");
         cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Welfare Call: Callback complete");
     });
-    it.only('it displays the case notes', () => {
+    it('it displays the case notes', () => {
         cy.url().should('match', /\/helpcase-profile\/\d+$/);
         cy.get('[data-testid=support-requested-table-view_link-0]')
             .contains('View')

--- a/src/components/CaseNotes/CaseNotes.jsx
+++ b/src/components/CaseNotes/CaseNotes.jsx
@@ -1,17 +1,24 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { helpTypes } from "../../helpers/constants"
 import Dropdown from "../../components/Form/Dropdown/Dropdown";
 import styles from '../CaseNotes/CaseNotes.module.scss';
 
 export default function CaseNotes({ caseNotes }) {
-    const [filterBy, setFilterBy] = useState("All")
+    const [filterBy, setFilterBy] = useState("")
+    useEffect(()=>{
+        if(caseNotes.manageCaseNotePage){
+            setFilterBy(caseNotes.helpNeeded)
+        }else{
+            setFilterBy("All")
+        }
+    },[])
     const hanleOnChange = (selectedCaseNoteType) => {
         setFilterBy(selectedCaseNoteType)
     }
     return (
         <div>
             <h2 className="govuk-heading-l">Case notes</h2>
-            { caseNotes["All"].length == 0 && 
+            { caseNotes[filterBy]?.length == 0 && 
                 <>
                     <div className ={ styles['case-notes-box']}>No previous case notes</div>
                     <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />

--- a/src/components/CaseNotes/CaseNotes.jsx
+++ b/src/components/CaseNotes/CaseNotes.jsx
@@ -6,26 +6,27 @@ import styles from '../CaseNotes/CaseNotes.module.scss';
 export default function CaseNotes({ caseNotes }) {
     const [filterBy, setFilterBy] = useState("")
     useEffect(()=>{
-        if(caseNotes?.manageCaseNotePage){
-            setFilterBy(caseNotes.helpNeeded)
+        if(caseNotes?.helpType){
+            setFilterBy(caseNotes.helpType)
         }else{
             setFilterBy("All")
         }
-    },[])
+    },[caseNotes])
     const hanleOnChange = (selectedCaseNoteType) => {
         setFilterBy(selectedCaseNoteType)
     }
     return (
         <div>
             <h2 className="govuk-heading-l">Case notes</h2>
-            {caseNotes && caseNotes[filterBy]?.length == 0 && 
+
+                {caseNotes && !caseNotes.helpType && <Dropdown  onChange={(e) => hanleOnChange(e)} dropdownItems ={helpTypes}></Dropdown>}
+                {caseNotes && caseNotes[filterBy]?.length == 0 && 
                 <>
                     <div className ={ styles['case-notes-box']}>No previous case notes</div>
                     <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
                 </>}
-                { caseNotes && caseNotes.All.length > 0 && <Dropdown  onChange={(e) => hanleOnChange(e)} dropdownItems ={helpTypes}></Dropdown>}
 
-            { caseNotes && caseNotes[filterBy]?.map((caseNote, i) => {
+            { caseNotes &&caseNotes[filterBy]?.map((caseNote, i) => {
                 return (
                     <>
                         <div

--- a/src/components/CaseNotes/CaseNotes.jsx
+++ b/src/components/CaseNotes/CaseNotes.jsx
@@ -6,7 +6,7 @@ import styles from '../CaseNotes/CaseNotes.module.scss';
 export default function CaseNotes({ caseNotes }) {
     const [filterBy, setFilterBy] = useState("")
     useEffect(()=>{
-        if(caseNotes.manageCaseNotePage){
+        if(caseNotes?.manageCaseNotePage){
             setFilterBy(caseNotes.helpNeeded)
         }else{
             setFilterBy("All")
@@ -18,31 +18,29 @@ export default function CaseNotes({ caseNotes }) {
     return (
         <div>
             <h2 className="govuk-heading-l">Case notes</h2>
-            { caseNotes[filterBy]?.length == 0 && 
+            {caseNotes && caseNotes[filterBy]?.length == 0 && 
                 <>
                     <div className ={ styles['case-notes-box']}>No previous case notes</div>
                     <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
                 </>}
-                {caseNotes.All.length > 0 && <Dropdown  onChange={(e) => hanleOnChange(e)} dropdownItems ={helpTypes}></Dropdown>}
+                { caseNotes && caseNotes.All.length > 0 && <Dropdown  onChange={(e) => hanleOnChange(e)} dropdownItems ={helpTypes}></Dropdown>}
 
-            {caseNotes[filterBy]?.map((caseNote, i) => {
-                if(caseNote){
-                    return (
-                        <>
-                            <div
-                                key={i}
-                                id={`case-note-${i}`}
-                                className={`filter ${styles['case-notes-box']}`}
-                                data-testid="case-note-entry">
-                                <h4 className="govuk-heading-s">
-                                    {caseNote.formattedDate} by {caseNote.author}
-                                </h4>
-                                <p>{caseNote.helpNeeded}: {caseNote.note}</p>
-                            </div>
-                            <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-                        </>
-                    );
-                }
+            { caseNotes && caseNotes[filterBy]?.map((caseNote, i) => {
+                return (
+                    <>
+                        <div
+                            key={i}
+                            id={`case-note-${i}`}
+                            className={`filter ${styles['case-notes-box']}`}
+                            data-testid="case-note-entry">
+                            <h4 className="govuk-heading-s">
+                                {caseNote.formattedDate} by {caseNote.author}
+                            </h4>
+                            <p>{caseNote.helpNeeded}: {caseNote.note}</p>
+                        </div>
+                        <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+                    </>
+                );
             })}
         </div>
     );

--- a/src/pages/helpcase-profile/[residentId]/index.js
+++ b/src/pages/helpcase-profile/[residentId]/index.js
@@ -36,7 +36,6 @@ export default function HelpcaseProfile({ residentId }) {
             helpRequests.forEach(hr => {
                 if(!hr.caseNotes) return
                 hr.caseNotes.forEach(caseNote => {
-                    console.log("case note", caseNote)
                     categorisedCaseNotes[caseNote.helpNeeded].push(caseNote)
                     categorisedCaseNotes['All'].push(caseNote)
                 });

--- a/src/pages/helpcase-profile/[residentId]/index.js
+++ b/src/pages/helpcase-profile/[residentId]/index.js
@@ -10,7 +10,6 @@ import CallHistory from '../../../components/CallHistory/CallHistory';
 import CaseNotes  from "../../../components/CaseNotes/CaseNotes";
 import { useState, useEffect } from 'react';
 import { helpTypes } from "../../../helpers/constants";
-import { isJSON, formatDate, getAuthor, getDate, getNote, getNonJsonCasenotesArray } from "../../../helpers/case_notes_helper";
 
 export default function HelpcaseProfile({ residentId }) {
     const [resident, setResident] = useState([]);
@@ -36,37 +35,12 @@ export default function HelpcaseProfile({ residentId }) {
                                         "CEV":[]}
             helpRequests.forEach(hr => {
                 if(!hr.caseNotes) return
-                if(isJSON(hr.caseNotes)){
-                    let caseNoteObject = JSON.parse(hr.caseNotes)
-                    if(caseNoteObject.length > 1){
-                        caseNoteObject.forEach(note => {
-                            note.formattedDate = formatDate(note.noteDate)
-                            note.helpNeeded = hr.helpNeeded
-                            categorisedCaseNotes[hr.helpNeeded].push(note)
-                            categorisedCaseNotes['All'].push(note)
-                        });
-                    }else{
-                        caseNoteObject[0].formattedDate = formatDate(caseNoteObject[0].noteDate)
-                        caseNoteObject[0].helpNeeded = hr.helpNeeded
-                        categorisedCaseNotes[hr.helpNeeded].push(caseNoteObject[0])
-                        categorisedCaseNotes['All'].push(caseNoteObject[0])
-                    }
-                }
-                else if(!isJSON(hr.caseNotes)){
-                    let nonJsonCaseNotesArray = getNonJsonCasenotesArray(hr.caseNotes)
-                    nonJsonCaseNotesArray.forEach(nonJsonCaseNote => {
-                        if (nonJsonCaseNote) {
-                            let caseNoteObject = {"author": getAuthor(nonJsonCaseNote),
-                                                        "formattedDate": formatDate(getDate(nonJsonCaseNote)),
-                                                        "note": getNote(nonJsonCaseNote),
-                                                        "helpNeeded":hr.helpNeeded,
-                                                        "noteDate": getDate(nonJsonCaseNote)
-                                                        }
-                            categorisedCaseNotes[hr.helpNeeded].push(caseNoteObject) 
-                            categorisedCaseNotes.All.push(caseNoteObject)
-                        }
-                    });
-                }
+                hr.caseNotes.forEach(caseNote => {
+                    console.log("case note", caseNote)
+                    categorisedCaseNotes[caseNote.helpNeeded].push(caseNote)
+                    categorisedCaseNotes['All'].push(caseNote)
+                });
+            
                 helpTypes.forEach(helpType => {
                     categorisedCaseNotes[helpType].sort((a, b) => new Date(b.noteDate) - new Date(a.noteDate))
                 });

--- a/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
+++ b/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
@@ -24,7 +24,8 @@ export default function addSupportPage({residentId, helpRequestId}) {
         "Welfare Call":[],
         "Help Requesst":[],
         "Contact Tracing":[],
-        "CEV":[]
+        "CEV":[],
+        "helpType": null
     })
 
     const router = useRouter()
@@ -56,7 +57,7 @@ export default function addSupportPage({residentId, helpRequestId}) {
             helpTypes.forEach(helpType => {
                 categorisedCaseNotes[helpType].sort((a, b) => new Date(b.noteDate) - new Date(a.noteDate))
             });
-            console.log(categorisedCaseNotes)
+            categorisedCaseNotes.helpType = response.helpNeeded
             setCaseNotes(categorisedCaseNotes)
             setHelpRequest(response);
             setCalls(response.helpRequestCalls.sort((a,b) => new Date(b.callDateTime) - new Date(a.callDateTime)))


### PR DESCRIPTION
**What**
- Add case notes to manage request profile
- Fix bug which was breaking the edit page

**Why**
- So users to view case notes attached to individual help request on the manage request profile

**Ticket**
https://trello.com/c/gOKNuEE7/59-as-a-call-handler-i-can-see-case-notes-for-a-specific-help-request-within-manage-request-page
**Screenshot**
![image](https://user-images.githubusercontent.com/46002877/106922001-7b3c1f80-6704-11eb-8650-abee7eb6a84d.png)

