### PR TITLE
Make call outcome hyperlinked on the support table

### DIFF
--- a/src/components/SupportTable/SupportTable.jsx
+++ b/src/components/SupportTable/SupportTable.jsx
@@ -32,7 +32,9 @@ export default function SupportTable({helpRequests}) {
 								if(hr.callbackRequired == true){
 									return (	<tr className="govuk-table__row" data-testid="support-requested-table_row">
 									<td className="govuk-table__cell" data-testid="support-requested-table-help-needed">{hr.helpNeeded}</td>
-									<td className="govuk-table__cell">{hr.upcomingCallOutcome}</td>
+									<td className="govuk-table__cell"><Link
+										href="/helpcase-profile/[resident_id]/manage-request/[help_request]"
+										as={`/helpcase-profile/${hr.residentId}/manage-request/${hr.id}`}>{hr.upcomingCallOutcome}</Link></td>
 									<td className="govuk-table__cell" data-testid="support-requested-table-calls-count">{hr.helpRequestCalls?.length}</td>
 									<td className="govuk-table__cell" data-testid={`support-requested-table-view_link-${index}`}><Link
 												href="/helpcase-profile/[resident_id]/manage-request/[help_request]"


### PR DESCRIPTION
As above, because "view" is ambiguous.