### PR TITLE
Add case notes to add support page

### DIFF
--- a/src/pages/add-support/[residentId]/index.js
+++ b/src/pages/add-support/[residentId]/index.js
@@ -29,7 +29,7 @@ export default function addSupportPage({residentId}) {
 		await retreiveResidentAndUser()
 	}, []);
 
-	const saveFunction = async function(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade) {
+	const saveFunction = async function(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote) {
 		let callRequestObject = {
 			callType: helpNeeded,
 			callDirection: callDirection,
@@ -46,7 +46,17 @@ export default function addSupportPage({residentId}) {
 				let helpRequestCallGateway = new HelpRequestCallGateway()
 				let helpRequestCallId = await helpRequestCallGateway.postHelpRequestCall(helpRequestId, callRequestObject)
 			}
-
+			if (caseNote && caseNote != "") {
+				const caseNotesGateway = new CaseNotesGateway();
+				const caseNoteObject = {
+						caseNote,
+						author: user.name,
+						noteDate: new Date().toGMTString(),
+						helpNeeded: helpNeeded
+				};      
+				await caseNotesGateway.createCaseNote(helpRequestId, residentId, caseNoteObject);
+			}
+			
 			router.push(`/helpcase-profile/${residentId}`)
 		} catch (err) {
 			console.log("Add support error", err)
@@ -64,7 +74,7 @@ export default function addSupportPage({residentId}) {
 						<KeyInformation resident={resident}/>
 					</div>
 					<div className="govuk-grid-column-three-quarters-from-desktop">
-						<CallbackForm residentId={residentId} resident={resident} backHref={backHref} saveFunction={saveFunction} />
+						<CallbackForm residentId={residentId} resident={resident} backHref={backHref} saveFunction={saveFunction} editableCaseNotes={true}  />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
**What**
- Add Case notes to the add support page

**Why**
- So the call handlers can log case notes when logging a new help request