### PR TITLE
Set initialCallbackCompleted as part of patch help request

### DIFF
--- a/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
+++ b/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
@@ -96,7 +96,8 @@ export default function addSupportPage({residentId, helpRequestId}) {
             const helpRequestGateway = new HelpRequestGateway();
 
             let patchHelpRequest = {
-                callbackRequired: helpRequestObject.callbackRequired
+                callbackRequired: helpRequestObject.callbackRequired,
+                initialCallbackCompleted: helpRequestObject.initialCallbackCompleted
             }
 
             await helpRequestGateway.patchHelpRequest(helpRequestId, patchHelpRequest);


### PR DESCRIPTION
Callbacks weren't falling off the callbacks list because initial callback completed wasn't being set