### PR TITLE
A workaround for when help-requests are split over duplicate resident…

### DIFF
--- a/src/pages/helpcase-profile/[residentId]/index.js
+++ b/src/pages/helpcase-profile/[residentId]/index.js
@@ -40,10 +40,14 @@ export default function HelpcaseProfile({ residentId }) {
             residentCaseNotes.forEach(caseNote => {
                 if(!caseNote) return
                 caseNote.caseNote.forEach(note => {
-                    let helpNeeded = helpRequests.filter(hr => hr.id == caseNote.helpRequestId)[0].helpNeeded
-                    note.helpNeeded = helpNeeded
-                    if (note && note.helpNeeded && note.helpNeeded in categorisedCaseNotes) { categorisedCaseNotes[note.helpNeeded].push(note) }
-                    categorisedCaseNotes['All'].push(note)
+                    let helpNeeded = helpRequests.filter(hr => hr.id == caseNote.helpRequestId);
+                    // a hack to mitigate bad data
+                    if (helpNeeded?.length > 0) {
+                        helpNeeded = helpNeeded[0].helpNeeded;
+                        note.helpNeeded = helpNeeded
+                        if (note && note.helpNeeded && note.helpNeeded in categorisedCaseNotes) { categorisedCaseNotes[note.helpNeeded].push(note) }
+                        categorisedCaseNotes['All'].push(note)
+                    }
                 });
 
                 helpTypes.forEach(helpType => {


### PR DESCRIPTION
# Bug:
No data is showing up for a record that was uploaded from PowerBI extract. No call type is on the record, the contact details are not showing, no help requests or case notes are listed either. [_(Trello ticket 71)_](https://trello.com/c/g6clapaW/71-bug-call-request-and-contact-details-not-showing).

<div align="center">

|  Empty help-case profile page |
| :----------------------------------------: |
|     <img src="https://user-images.githubusercontent.com/43747286/107772361-100dd100-6d34-11eb-83af-029f0bf85b20.png" width="500">     |

</div>



# What:
 - This PR adds a check for whether at least 1 help request exists such that any of retrieved case notes would be registered against it.

# Why:
The changed front-end code was written with an **assumption** that there's only 1 unique resident & that when we visit a profile page we retrieve **ALL** of the help requests and **ALL** of the case notes.

Now, it turns out that due to poor quality of data, sometimes the [resident de-duplication code](https://github.com/LBHackney-IT/cv-19-res-support-v3/blob/development/cv19ResSupportV3/V3/Gateways/ResidentGateway.cs#L168-L202) trips-up and fails to recognise the resident as duplicate.

 Duplicate Resident Records             |  Bad data causing them to be seen as unique
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/43747286/107770295-18184180-6d31-11eb-948a-75f79a8220c1.png)  | ![image](https://user-images.githubusercontent.com/43747286/107770493-63caeb00-6d31-11eb-8044-d97d9b8a8496.png)

Hence we end up with **multiple instances** of the same resident under **different id's** that house **different help-requests** under them. In essence, the **help-requests** that would be under a single resident record, **are split under multiple resident duplicates** that act as different resident.
<div align="center">

|  Duplicate resident ids _(left)_ & scattered help-requests _(right)_ |
| :----------------------------------------: |
|     <img src="https://user-images.githubusercontent.com/43747286/107767994-b0acc280-6d2d-11eb-87f4-21058d58894f.png" width="350">     |

</div>

The reason why this is an issue on the front-end is that, whenever a call handler navigates to any **helpcase-profile** _(it's actually resident profile page - bad naming)_ page, they can only see data for one of these duplicate residents by design. This means upon visiting a duplicate resident page, only a subset of ALL existing help-requests for that person is retrieved _(as the help requests for resident are queried by resident id)_.

<div align="center">

|  Retrieved help requests on a duplicate resident page|
| :----------------------------------------: |
|     <img src="https://user-images.githubusercontent.com/43747286/107773514-aabadf80-6d35-11eb-94df-44b79017c31e.png" width="350">     |

</div>

Same goes for the retrieval of case notes upon visiting a duplicate resident page _(since they also get queried only by resident id)_.

<div align="center">

|  Retrieved case notes  on a duplicate resident page|
| :----------------------------------------: |
|     <img src="https://user-images.githubusercontent.com/43747286/107773939-477d7d00-6d36-11eb-87ec-10f898605399.png" width="350">     |

</div>

Now, the key thing to note is that we are **retrieving many Case Notes registered against Resident's 11739**. Some of these Case Notes **are registered against Help Request 11506**. However upon visiting Resident's 11739 profile page, we **did not retrieve a Help Request 11506**! _(The reason why the Help Request 11506 is not registered against Resident 11739 is unclear - investigation is still being done.)_

Not having help request 11506 is an issue for the front-end because of the following [code](https://github.com/LBHackney-IT/coronavirus-here-to-help-frontend/blob/master/src/pages/helpcase-profile/%5BresidentId%5D/index.js#L42-L47). It happens on **line 43**, because once the Case Note associated with Help Request 11506 is reached, the filter condition is trying to find a help-request with id of 11506, which wasn't retrieved as seen earlier. Meaning the **code ends up attempting to grab zeroth element of an empty array and access its helpNeeded property** - resulting in `TypeError: Cannot read property 'helpNeeded' of undefined`, which exits the try-catch block.

<div align="center">

|  Code that is crashing and stopping the data render  |
| :----------------------------------------: |
|     <img src="https://user-images.githubusercontent.com/43747286/107775744-9fb57e80-6d38-11eb-8c89-0c51d9340ada.png" width="750">     |

</div>


# Notes:
 - The real fix to a problem would be correcting the bad data by merging in the duplicate resident records together.
 - This fix is done with the idea that the entire page shouldn't crash just because couple case-notes failed to match.
 - However logging such an occurrence in some way should be considered.
 
# Thoughts:
 - Maybe we should reconsider using "data of birth" as indicator of uniqueness on the back-end API?
 - Is this really a PowerBI record? If not, could the Help Request 11506 have been re-registered on a different resident duplicate during the Migration of splitting tables and records? `It's weird that the case notes that were registered on Help Request 11506, got registered on a resident with completely different ID than Help Request itself!!!`

# Collaborators:
 - Paired on investigation with @ben-d758 @kosiakkatrina 