### PR TITLE
Fix parameter order in createCaseNote gateway method

### DIFF
--- a/src/gateways/case-notes.js
+++ b/src/gateways/case-notes.js
@@ -20,7 +20,7 @@ export class CaseNotesGateway extends DefaultGateway {
           console.log("helpRequestCaseNoteResponse",response)
         return InboundMapper.ToCaseNotes(response);
     }
-    async createCaseNote(residentId, helpRequestId, caseNoteObject) {
+    async createCaseNote(helpRequestId, residentId, caseNoteObject) {
         return await this.postToUrl(
             `v4/residents/${residentId}/help-requests/${helpRequestId}/case-notes`,
             ToRequest(caseNoteObject)

--- a/src/gateways/case-notes.test.js
+++ b/src/gateways/case-notes.test.js
@@ -141,7 +141,7 @@ describe('Case notes gateway', () => {
         );
 
         // act
-        await caseNotesGateway.createCaseNote(randomResidentId, randomHelpRequestId, mockDomainCaseNoteBody);
+        await caseNotesGateway.createCaseNote(randomHelpRequestId, randomResidentId, mockDomainCaseNoteBody);
 
         // assert
         let request = moxios.requests.mostRecent();


### PR DESCRIPTION
**What**
- Swap helpRequestId and residentId order in the createCaseNote gateway method

**Why**
- The method called in the components pass in the parameters in the incorrect order