### PR TITLE
Merge Preventing multi-submit on button click spam

### DIFF
--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -24,6 +24,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
     const [textTemplatePreview, setTextTemplatePreview] = useState(null)
     const [showEmail, setShowEmail] = useState(false)
     const [showText, setShowText] = useState(false)
+    const [submitEnabled, setSubmitEnabled] = useState(true);
 
     const [errors, setErrors] = useState({
         CallbackRequired: null,
@@ -225,6 +226,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
             (callMade == false && helpNeeded && followUpRequired != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
             (followUpRequired != null && caseNote !="" && helpNeeded != null && helpNeeded != "" && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText))
         ) {
+            setSubmitEnabled(false);
             saveFunction(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email);
         } else {
             setErrorsExist(true);
@@ -674,6 +676,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
                             onClick={(event) => {
                                 handleUpdate(event);
                             }}
+                            disabled={!submitEnabled}
                             data-testid="callback-form-update_button"
                         />
                         <Link href={backHref}>


### PR DESCRIPTION
# What:
- Changes to prevent multiple submission & saving of the same data due to submit button being spam clicked

# Why:
- Because duplicate records were being created. While the duplicates don't cause an issue functionality-wise, they made tool user's job more complicated by creating confusion.

# Notes:
- Will happen on successful validation just before the data is sent to the gateway to be saved.

# Ticket:
- Trello ticket number: [68](https://trello.com/c/hiMwoo6d/68-bug-clicking-update-on-add-new-support-page-twice-quickly-means-that-two-help-requests-are-created-on-the-resident-profile).