### PR TITLE
Correct time difference between case notes and help request calls

### DIFF
--- a/src/pages/add-support/[residentId]/index.js
+++ b/src/pages/add-support/[residentId]/index.js
@@ -33,11 +33,14 @@ export default function addSupportPage({residentId}) {
 	}, []);
 
 	const saveFunction = async function(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email) {
+		const tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds
+		const localTimeTZCorrectedBase = new Date(Date.now() - tzoffset);
+		
 		let callRequestObject = {
 			callType: helpNeeded,
 			callDirection: callDirection,
 			callOutcome: callOutcomeValues,
-			callDateTime: new Date(),
+			callDateTime: localTimeTZCorrectedBase,
 			callHandler: user.name
 		}
 

--- a/src/pages/add-support/[residentId]/index.js
+++ b/src/pages/add-support/[residentId]/index.js
@@ -11,6 +11,7 @@ import {CaseNotesGateway} from "../../../gateways/case-notes";
 import {useRouter} from "next/router";
 import {GovNotifyGateway} from '../../../gateways/gov-notify'
 import { TEST_AND_TRACE_FOLLOWUP_EMAIL, TEST_AND_TRACE_FOLLOWUP_TEXT } from "../../../helpers/constants";
+import getTimeZoneCorrectedLocalDate from "../../../../tools/etcUtility"
 
 export default function addSupportPage({residentId}) {
 	const backHref = `/helpcase-profile/${residentId}`;
@@ -33,14 +34,11 @@ export default function addSupportPage({residentId}) {
 	}, []);
 
 	const saveFunction = async function(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email) {
-		const tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds
-		const localTimeTZCorrectedBase = new Date(Date.now() - tzoffset);
-		
 		let callRequestObject = {
 			callType: helpNeeded,
 			callDirection: callDirection,
 			callOutcome: callOutcomeValues,
-			callDateTime: localTimeTZCorrectedBase,
+			callDateTime: getTimeZoneCorrectedLocalDate(),
 			callHandler: user.name
 		}
 

--- a/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
+++ b/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
@@ -86,12 +86,14 @@ export default function addSupportPage({residentId, helpRequestId}) {
     }, []);
 
     const saveFunction = async function(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email) {
-        console.log("helpNeeded",helpNeeded)
+        const tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds
+        const localTimeTZCorrectedBase = new Date(Date.now() - tzoffset);
+
         const callRequestObject = {
             callType: helpNeeded,
             callDirection: callDirection,
             callOutcome: callOutcomeValues,
-            callDateTime: new Date(),
+            callDateTime: localTimeTZCorrectedBase,
             callHandler: user.name
         }
 

--- a/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
+++ b/src/pages/helpcase-profile/[residentId]/manage-request/[helpRequestId].js
@@ -14,6 +14,7 @@ import CaseNotes from '../../../../components/CaseNotes/CaseNotes';
 import { helpTypes } from "../../../../helpers/constants";
 import {GovNotifyGateway} from '../../../../gateways/gov-notify'
 import {TEST_AND_TRACE_FOLLOWUP_TEXT, TEST_AND_TRACE_FOLLOWUP_EMAIL} from '../../../../helpers/constants'
+import getTimeZoneCorrectedLocalDate from "../../../../../tools/etcUtility"
 
 export default function addSupportPage({residentId, helpRequestId}) {
     const backHref = `/helpcase-profile/${residentId}`;
@@ -86,14 +87,11 @@ export default function addSupportPage({residentId, helpRequestId}) {
     }, []);
 
     const saveFunction = async function(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email) {
-        const tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds
-        const localTimeTZCorrectedBase = new Date(Date.now() - tzoffset);
-
         const callRequestObject = {
             callType: helpNeeded,
             callDirection: callDirection,
             callOutcome: callOutcomeValues,
-            callDateTime: localTimeTZCorrectedBase,
+            callDateTime: getTimeZoneCorrectedLocalDate(),
             callHandler: user.name
         }
 

--- a/tools/etcUtility.js
+++ b/tools/etcUtility.js
@@ -1,0 +1,8 @@
+// Returns British Summer Time (if in effect) corrected date.
+// This function is used for date fields that are about to be
+// implicitly converted to ISO date.
+export default function getTimeZoneCorrectedLocalDate() {
+    const tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds
+    const localTimeTZCorrectedBase = new Date(Date.now() - tzoffset);
+    return localTimeTZCorrectedBase;
+}


### PR DESCRIPTION
# What:
- Made help request calls creation date use function that corrects for time zone offset.

# Why:
- Upon adding a new support ticket, ticket's associated case notes & help request calls have different times (differ by an hour). This causes confusion for call handlers.

# Notes:
- The offset being corrected for is British Summer Time.
- Other dates apart from the ones changed in this PR don't get impacted due to them being saved in GMT string format rather than ISO date.

# Ticket:
- Trello ticket number: [177](https://trello.com/c/JYt7kL13/177-bug-created-call-time-does-not-match-the-associated-case-note-time).
