### PR TITLE
Data saving failures

### DIFF
--- a/src/pages/create-resident.js
+++ b/src/pages/create-resident.js
@@ -32,12 +32,16 @@ export default function CreateResident({}) {
         setResident({ ...resident, ...object });
     };
 
-    const saveResident = async () => {
+    const saveResident = (event) => {
         event.preventDefault();
         const residentGateway = new ResidentGateway();
-        const newResident = await residentGateway.postResident(resident);
-        console.log('resident response', newResident);
-        router.push(`/helpcase-profile/${newResident.Id}`);
+        residentGateway.postResident(resident).then((newResident) => {
+            console.log('resident response', newResident);
+            router.push(`/helpcase-profile/${newResident.Id}`);
+        }).catch((e) => {
+            console.log(`Post failed! ${e}`);
+            alert('Resident could not be created.');
+        });
     };
 
     const onInvalidField = (id) => {

--- a/src/pages/helpcase-profile/[residentId]/editresident.js
+++ b/src/pages/helpcase-profile/[residentId]/editresident.js
@@ -33,11 +33,16 @@ export default function EditResident({ residentId }) {
         setUpdatedResident({ ...updatedResident, ...object });
     };
 
-    const saveResident = () => {
+    const saveResident = (event) => {
         event.preventDefault();
         const residentGateway = new ResidentGateway();
-        residentGateway.setResident(residentId, updatedResident);
-        Router.back();
+        residentGateway.setResident(residentId, updatedResident).then(() => {
+            console.log("Patch complete!")
+            Router.back();
+        }).catch((e) => {
+            console.error(`Patch failed! ${e}`);
+            alert('New resident information failed to be saved.');
+        });
     };
 
     useEffect(() => {}, [resident]);


### PR DESCRIPTION
# What:
- Patch Resident promise handling in edit-resident page _(added .then)_.
- Post Resident promise handling in create-resident page _(added .catch, and used .then instead of await)_.
- Patch & Post Resident - prevented the page from navigating away when an error happens.
- Patch & Post Resident - made an alert pop-up & a console log upon error.
- Added promise error handling for all of the data saving requests (Post & Patch) in the add-support & manage-request pages.
- Prevented the add-support & manage-request pages from navigating away upon failure.
- Added alert pop-ups and console logs for the failure case on  add-support & manage-request pages.

# Why:
- When, for instance, an edit-resident form was opened and left in one of the browsers tabs, after extended period of time if the form submission is triggered, the request for saving data gets cancelled. This only happens if the form is left open for a period of about 20-30+ minutes, otherwise it works fine as intended. It's likely related to AWS Lambda function having been de-spun & once the request comes into it, it tries to load the reload the page, hence cancelling the request from the page being reloaded. But I don't understand enough to confirm it.
- While it may seem that 30 minute duration shouldn't be an issue & simple form could easily be filled in and submitted before the the time mark that causes failure, it's not completely true & it has to do of how the user _(the call handlers)_ are working with the tool. Some calls can last up to 40 minutes, and even when they don't the calls might get rescheduled half way through, leaving a form filled in half way in one of the tabs until the person gets called again to finish the job off. Of course, there are more nuances than that. The users could reload the form, but then they need to back-up any entered data, which makes this a non-solution.

# Notes:
- In create-resident page I replaced the await with .then because it's easier to read once .catch is involved, it was a simple enough function & it would be near identical to the edit-resident code.
- Prevented navigating away upon failures as the data loss is unacceptable due to it cause pointless delays and difficulties.
- Alerting user via pop-up about the errors to increase the visibility of errors, and to make the user aware what kind of information was not saved.
- Added user side console error logs to make it easier to find where the issue has happened. Issue this PR tackles can only be reproduced on the Cloud environment and not locally, hence it is handy to have logs in place at all times.
- The add-support & manage-request page's data saving functions are using a hybrid async, await & .catch syntax. It just turned out that changing everything into .then.catch syntax will make it harder to read due to the nesting. Same applies to doing more specific error handling with try-catch blocks - the nesting would make it hard to look at. Hence the hybrid method was used.
- Added more descriptive error handling to the add-support & manage-request pages than the previously existing single catch all catch block of 'An error has happened', so that it would be clear which requests out of 7 that are made have failed, which will help tremendously in any future debugging.