### PR TITLE
Fix create-resident page sometimes not saving some of the fields

### DIFF
--- a/src/components/EditResidentBioForm/EditResidentBioForm.jsx
+++ b/src/components/EditResidentBioForm/EditResidentBioForm.jsx
@@ -33,7 +33,7 @@ export default function EditResidentBioForm({ resident, onChange, validation, on
                                 marginBottom: '20px'
                             }}
                             defaultValue={resident.firstName}
-                            onKeyUp={(e) => onChange(e.target.id, e.target.value)}
+                            onChange={(e) => onChange(e.target.id, e.target.value)}
                             data-testid="first-name-input"
                             required
                             onInvalid={(e) => onInvalidField(e.target.id)}
@@ -64,7 +64,7 @@ export default function EditResidentBioForm({ resident, onChange, validation, on
                                 marginBottom: '20px'
                             }}
                             defaultValue={resident.lastName}
-                            onKeyUp={(e) => onChange(e.target.id, e.target.value)}
+                            onChange={(e) => onChange(e.target.id, e.target.value)}
                             data-testid="last-name-input"
                             required
                             onInvalid={(e) => onInvalidField(e.target.id)}
@@ -97,7 +97,7 @@ export default function EditResidentBioForm({ resident, onChange, validation, on
                                 marginBottom: '20px'
                             }}
                             defaultValue={resident.contactTelephoneNumber}
-                            onKeyUp={(e) => onChange(e.target.id, e.target.value)}
+                            onChange={(e) => onChange(e.target.id, e.target.value)}
                             data-testid="contact-telephone-input"
                             required
                             pattern="^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\s\./0-9]*$"
@@ -175,7 +175,7 @@ export default function EditResidentBioForm({ resident, onChange, validation, on
                             maxLength="2"
                             inputMode="numeric"
                             defaultValue={resident.dobDay}
-                            onKeyUp={(e) => onChange(e.target.id, e.target.value)}
+                            onChange={(e) => onChange(e.target.id, e.target.value)}
                             data-testid="dobDay-input"
                             required
                             onInvalid={(e) => onInvalidField(e.target.id)}
@@ -194,7 +194,7 @@ export default function EditResidentBioForm({ resident, onChange, validation, on
                             maxLength="2"
                             inputMode="numeric"
                             defaultValue={resident.dobMonth}
-                            onKeyUp={(e) => onChange(e.target.id, e.target.value)}
+                            onChange={(e) => onChange(e.target.id, e.target.value)}
                             data-testid="dobMonth-input"
                             required
                             onInvalid={(e) => onInvalidField(e.target.id)}
@@ -213,7 +213,7 @@ export default function EditResidentBioForm({ resident, onChange, validation, on
                             maxLength="4"
                             inputMode="numeric"
                             defaultValue={resident.dobYear}
-                            onKeyUp={(e) => onChange(e.target.id, e.target.value)}
+                            onChange={(e) => onChange(e.target.id, e.target.value)}
                             data-testid="dobYear-input"
                             required
                             onInvalid={(e) => onInvalidField(e.target.id)}


### PR DESCRIPTION
# What:
- Changed the trigger for updating edit-resident-bio form _(used in create-resident & edit-resident pages)_ from "onKeyUp" to "onChange".

# Why:
- Users have reported that occasionally upon attempting to create a new resident, the information in some of the fields does not get saved - information such as "First Name", "Last Name", "Phone Number". While using the form, I noticed that under certain circumstances, the request it sends out contains only some of the populated fields, which implies that the issue stems from something state related. With the help of React dev tools, I've found that the "Resident" object state does not get updated for the reported fields, which has led me to find this trigger issue.

# Notes:
- I've tested the fix for this problem and it seems fixed, however... I'm not 100% sure that this was the cause for the reported problems. While whatever I found matches the description, I have no way of knowing if there perhaps were 2 causes for the problem and I only fixed one of them.
- The confusion stems from that I was only able to reproduce the reported description of the bug by using form-filling dev tool, which has bypassed the "onKeyUp" trigger. I've tried to reproduce the issue by natural means of: typing data manually, copy-pasting & using chrome's autofill - none of these methods have managed to reproduce the bug. It is possible that the user is maybe using some plugin to fill in the data, or a browser that trips up on that trigger, or anything else that does not acknowledge  "onKeyUp" under whatever circumstances the user is not telling me.
- I'm putting this as a solution out without being 100% as the bug is data loss related - we'll just have to see how it goes. This is a fix after all - I just hope this is a fix for whatever phenomenon user has ran into.