### PR TITLE
Added onChange handler for address lines fields so they could get captured & saved

### DIFF
--- a/src/components/Form/Address/index.jsx
+++ b/src/components/Form/Address/index.jsx
@@ -94,6 +94,7 @@ export default function Address({ initialResident, onChange }) {
                             name="addressFirstLine"
                             type="text"
                             onChange={(e) => handleManualAddressEntry(e.target.id, e.target.value)}
+                            placeholder="Address line 1"
                             value={
                                 resident.addressFirstLine
                                     ? resident.addressFirstLine
@@ -110,6 +111,7 @@ export default function Address({ initialResident, onChange }) {
                             name="addressSecondLine"
                             type="text"
                             onChange={(e) => handleManualAddressEntry(e.target.id, e.target.value)}
+                            placeholder="Address line 2"
                             value={
                                 resident.addressSecondLine
                                     ? resident.addressSecondLine
@@ -125,6 +127,7 @@ export default function Address({ initialResident, onChange }) {
                             name="addressThirdLine"
                             type="text"
                             onChange={(e) => handleManualAddressEntry(e.target.id, e.target.value)}
+                            placeholder="Address line 3"
                             value={
                                 resident.addressThirdLine
                                     ? resident.addressThirdLine
@@ -140,6 +143,7 @@ export default function Address({ initialResident, onChange }) {
                             name="postCode"
                             type="text"
                             onChange={(e) => handleManualAddressEntry(e.target.id, e.target.value)}
+                            placeholder="Post code"
                             value={
                                 resident.postCode ? resident.postCode : initialResident?.postCode
                             }

--- a/src/components/Form/Address/index.jsx
+++ b/src/components/Form/Address/index.jsx
@@ -36,6 +36,15 @@ export default function Address({ initialResident, onChange }) {
         resident = newResident;
         setResident(newResident);
     };
+
+    const handleManualAddressEntry = (addressInputId, addressInputValue) => {
+        // honestly, I don't think this component should be talking in terms of resident
+        // but I'll leave a TODO: change res to address.
+        const newResident = { ...resident, [addressInputId]: addressInputValue}
+        setResident(newResident);
+        onChange({ [addressInputId]: addressInputValue });
+    };
+
     useEffect(() => {}, [resident]);
 
     const dropdownItems =['Select an address'].concat(addresses?.map(
@@ -84,6 +93,7 @@ export default function Address({ initialResident, onChange }) {
                             id="addressFirstLine"
                             name="addressFirstLine"
                             type="text"
+                            onChange={(e) => handleManualAddressEntry(e.target.id, e.target.value)}
                             value={
                                 resident.addressFirstLine
                                     ? resident.addressFirstLine
@@ -99,6 +109,7 @@ export default function Address({ initialResident, onChange }) {
                             id="addressSecondLine"
                             name="addressSecondLine"
                             type="text"
+                            onChange={(e) => handleManualAddressEntry(e.target.id, e.target.value)}
                             value={
                                 resident.addressSecondLine
                                     ? resident.addressSecondLine
@@ -113,6 +124,7 @@ export default function Address({ initialResident, onChange }) {
                             id="addressThirdLine"
                             name="addressThirdLine"
                             type="text"
+                            onChange={(e) => handleManualAddressEntry(e.target.id, e.target.value)}
                             value={
                                 resident.addressThirdLine
                                     ? resident.addressThirdLine
@@ -124,9 +136,10 @@ export default function Address({ initialResident, onChange }) {
                     <div className="govuk-form-group lbh-form-group">
                         <input
                             className="govuk-input  lbh-input"
-                            id="postcode"
-                            name="postcode"
+                            id="postCode"
+                            name="postCode"
                             type="text"
+                            onChange={(e) => handleManualAddressEntry(e.target.id, e.target.value)}
                             value={
                                 resident.postCode ? resident.postCode : initialResident?.postCode
                             }


### PR DESCRIPTION
# What:
- Added an "onChange" trigger and a handler function to an Address sub-form for capturing manually entered Address Line data.
- Added placeholder text to the Address sub-form address line fields.

# Why:
- When call handlers _(users)_ are filling in or correcting resident details form page, they also have to put in the address. To make entering an address easier, a postcode address lookup was implemented for getting a list of address for a given postcode & then selecting one of them from the dropdown so that all the address lines would get auto-populated. It so happens that the Addresses API returning the addresses does not find all of the postcodes that users attempt to lookup. When this happens, the user attempts to enter address lines manually, however it does not get captured and hence it is not saved.
- The placeholder text to the postcode fields as we have a resident lookup page that accepts searching by postcode. As such, it's important that the postcode gets entered by user into the correct input for that resident to be findable by postcode later. Other fields have placeholder text mainly due to aesthetic reason as their values are quite chaotic even when coming from addresses API.

# Notes:
- One of the things that Addresses from Addresses API are used is to also populate UPRN number. However, if manual entry will be attempted _(on the address that Addresses API did not find)_, then no UPRN will be populated.