### PR TITLE
Replace welfare calls with self isolation on the frontend

### DIFF
--- a/cypress/integration/journeys/manage-a-help-request.spec.js
+++ b/cypress/integration/journeys/manage-a-help-request.spec.js
@@ -22,7 +22,7 @@ context('When you view a helpcase profile', () => {
             .click({ force: true });
         cy.get('[data-testid=call-history-entry]').should('have.length', 2);
         cy.get('[data-testid=call-history-entry]').first().should('contain', "2021-01-26 15:12 by handler");
-        cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Welfare Call: Callback complete");
+        cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Self Isolation Call: Callback complete");
     });
     it('it displays the case notes', () => {
         cy.url().should('match', /\/helpcase-profile\/\d+$/);

--- a/cypress/integration/pages/callbacks-list.spec.js
+++ b/cypress/integration/pages/callbacks-list.spec.js
@@ -36,7 +36,7 @@ describe('Callbacks list page filters callbacks correctly', () => {
     it('Upon selecting Help Case Type dropdown value, callbacks get filtered by that value', () => {
         cy.visit('/callback-list');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '6');
-        cy.get('[data-testid=help-type-dropdown]').select('Welfare Call');
+        cy.get('[data-testid=help-type-dropdown]').select('Self Isolation');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
         cy.get('[data-testid=help-type-dropdown]').select('Help Request');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '3');

--- a/cypress/integration/pages/helpcase-profile.spec.js
+++ b/cypress/integration/pages/helpcase-profile.spec.js
@@ -29,7 +29,7 @@ describe('View helpcase profile page', () => {
 
         cy.get('[data-testid=support-received-tab]').click({force: true})
         cy.get('[data-testid=support-received-table_row]').should('have.length', 1);
-        cy.get('[data-testid=support-received-table-help-needed]').first().should('contain', "Welfare Call");
+        cy.get('[data-testid=support-received-table-help-needed]').first().should('contain', "Self Isolation");
         cy.get('[data-testid=support-received-table-calls-count]').first().should('contain', "1");
     });
 
@@ -37,7 +37,7 @@ describe('View helpcase profile page', () => {
         cy.visit(`http://localhost:3000/helpcase-profile/3`);
         cy.get('[data-testid=call-history-entry]').should('have.length', 11);
         cy.get('[data-testid=call-history-entry]').first().should('contain', "2021-01-26 15:12 by Bart Simpson");
-        cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Welfare Call: Wrong number");
+        cy.get('[data-testid=call-history-entry]').first().should('contain', "outbound Self Isolation Call: Wrong number");
     });
     it('displays JSON and string case notes ordered by date', () => {
         cy.visit(`http://localhost:3000/helpcase-profile/3`);
@@ -49,18 +49,18 @@ describe('View helpcase profile page', () => {
         cy.get('[data-testid=case-note-entry]').first().should('contain', "CREATED");
         cy.get('[data-testid=case-note-entry]').last().should('contain', "by Ronald Weasley");
         cy.get('[data-testid=case-note-entry]').last().should('contain', "2020-09-06");
-        cy.get('[data-testid=case-note-entry]').last().should('contain', "Welfare Call: *** CREATED ***");
+        cy.get('[data-testid=case-note-entry]').last().should('contain', "Self Isolation: *** CREATED ***");
     })
     it('displays filtered case notes ordered by date', () => {
         cy.visit(`http://localhost:3000/helpcase-profile/3`);
-        cy.get('[data-testid=select-dropdown]').select("Welfare Call", {force: true})
+        cy.get('[data-testid=select-dropdown]').select("Self Isolation", {force: true})
         cy.get('[data-testid=case-note-entry]').should('have.length', 2);
         cy.get('[data-testid=case-note-entry]').first().scrollIntoView()
         cy.get('[data-testid=case-note-entry]').first().should('contain', "by Harry Potter");
         cy.get('[data-testid=case-note-entry]').first().should('contain', "2020-09-08");
-        cy.get('[data-testid=case-note-entry]').first().should('contain', "Welfare Call: *** CREATED ***");
+        cy.get('[data-testid=case-note-entry]').first().should('contain', "Self Isolation: *** CREATED ***");
         cy.get('[data-testid=case-note-entry]').last().should('contain', "by Ronald Weasley");
         cy.get('[data-testid=case-note-entry]').last().should('contain', "2020-09-06");
-        cy.get('[data-testid=case-note-entry]').last().should('contain', "Welfare Call: *** CREATED ***");
+        cy.get('[data-testid=case-note-entry]').last().should('contain', "Self Isolation: *** CREATED ***");
     })
 });

--- a/src/components/CallHistory/CallHistory.jsx
+++ b/src/components/CallHistory/CallHistory.jsx
@@ -17,10 +17,10 @@ export default function CaseNotes({ calls }) {
         <div>
             <h2 className="govuk-heading-l">Call history</h2>
             {calls.length < 1 &&
-             <>
-                <div className={styles['call-history-box'] }>No previous calls</div>
-                <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-             </>}
+                <>
+                    <div className={styles['call-history-box'] }>No previous calls</div>
+                    <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+                </>}
             {calls?.map((call, index) => {
                 return (
                     <>
@@ -34,8 +34,11 @@ export default function CaseNotes({ calls }) {
                                 {call.callHandler}
                             </h4>
                             <p>
-                                {call.callDirection} {call.callType}:{' '}
-                                {FormatCallOutcome(call.callOutcome)}
+                                {call.callDirection}{' '}
+                                {call.callType == 'Welfare Call'
+                                    ? 'Self Isolation Call'
+                                    : call.callType}
+                                : {FormatCallOutcome(call.callOutcome)}
                             </p>
                         </div>
                         <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />

--- a/src/components/CallbacksList/CallbacksList.jsx
+++ b/src/components/CallbacksList/CallbacksList.jsx
@@ -59,8 +59,14 @@ export default function CallbacksList({ callbacks }) {
                                 <td className="govuk-table__cell">{callback.residentName}</td>
                                 <td className="govuk-table__cell">{callback.address}</td>
                                 <td className="govuk-table__cell">{callback.requestedDate}</td>
-                                <td className="govuk-table__cell" data-testid="callbacks-table-call-type">
-                                    <span title="Contact Tracing">{callback.callType}</span>
+                                <td
+                                    className="govuk-table__cell"
+                                    data-testid="callbacks-table-call-type">
+                                    <span title="Contact Tracing">
+                                        {callback.callType == 'Welfare Call'
+                                            ? 'Self Isolation'
+                                            : callback.callType}
+                                    </span>
                                 </td>
                                 <td className="govuk-table__cell ">
                                     {callback.unsuccessfulCallAttempts}

--- a/src/components/CaseNotes/CaseNotes.jsx
+++ b/src/components/CaseNotes/CaseNotes.jsx
@@ -21,13 +21,21 @@ export default function CaseNotes({ caseNotes }) {
         }
     },[caseNotes])
     const hanleOnChange = (selectedCaseNoteType) => {
-        setFilterBy(selectedCaseNoteType)
+        setFilterBy(
+            selectedCaseNoteType == 'Self Isolation' ? 'Welfare Call' : selectedCaseNoteType
+        );
     }
     return (
         <div>
             <h2 className="govuk-heading-l">Case notes</h2>
 
-                {caseNotes && !caseNotes.helpType && displayDropdown&&<Dropdown  onChange={(e) => hanleOnChange(e)} dropdownItems ={helpTypes}></Dropdown>}
+                {caseNotes && !caseNotes.helpType && displayDropdown&&
+                 <Dropdown
+                 onChange={(e) => hanleOnChange(e)}
+                 dropdownItems={helpTypes
+                     .join(',')
+                     .replace('Welfare Call', 'Self Isolation')
+                     .split(',')}></Dropdown>}
                 {caseNotes && caseNotes[filterBy]?.length == 0 && 
                 <>
                     <div className ={ styles['case-notes-box']}>No previous case notes</div>
@@ -45,7 +53,12 @@ export default function CaseNotes({ caseNotes }) {
                             <h4 className="govuk-heading-s">
                                 {caseNote.formattedDate} by {caseNote.author}
                             </h4>
-                            <p>{caseNote.helpNeeded}: {caseNote.note}</p>
+                            <p>
+                                {caseNote.helpNeeded == 'Welfare Call'
+                                    ? 'Self Isolation'
+                                    : caseNote.helpNeeded}
+                                    : {caseNote.note}
+                            </p>
                         </div>
                         <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
                     </>

--- a/src/components/Form/RadioButtons/RadioButton.jsx
+++ b/src/components/Form/RadioButtons/RadioButton.jsx
@@ -28,7 +28,7 @@ export default function RadioButton({ radioButtonItems, name , optionalClass, on
                             for={elementId}
                             style={{marginBottom: "15px"}}
                         >
-                            {radioButtonItem}
+                            {radioButtonItem == 'Welfare Call' ? 'Self Isolation' : radioButtonItem}
                         </label>
                 </div>
                 )

--- a/src/components/SupportTable/SupportTable.jsx
+++ b/src/components/SupportTable/SupportTable.jsx
@@ -32,7 +32,11 @@ export default function SupportTable({helpRequests}) {
 							{helpRequests.map((hr, index) => {
 								if(hr.callbackRequired == true){
 									return (	<tr className="govuk-table__row" data-testid="support-requested-table_row">
-									<td className="govuk-table__cell" data-testid="support-requested-table-help-needed">{hr.helpNeeded}</td>
+									<td className="govuk-table__cell" data-testid="support-requested-table-help-needed">
+											{hr.helpNeeded == 'Welfare Call'
+                                                    ? 'Self Isolation'
+                                                    : hr.helpNeeded}
+									</td>
 									<td className="govuk-table__cell"><Link
 										href="/helpcase-profile/[resident_id]/manage-request/[help_request]"
 										as={`/helpcase-profile/${hr.residentId}/manage-request/${hr.id}`}>{hr.upcomingCallOutcome}</Link></td>
@@ -60,7 +64,11 @@ export default function SupportTable({helpRequests}) {
 							{helpRequests.map((hr) => {
 								if(hr.callbackRequired == false){
 									return (<tr className="govuk-table__row" data-testid="support-received-table_row">
-									<td className="govuk-table__cell" data-testid="support-received-table-help-needed">{hr.helpNeeded}</td>
+									<td className="govuk-table__cell" data-testid="support-received-table-help-needed">
+									{hr.helpNeeded == 'Welfare Call'
+                                                    ? 'Self Isolation'
+                                                    : hr.helpNeeded}
+									</td>
 									<td className="govuk-table__cell" data-testid="support-received-table-calls-count" >{hr.totalCompletedCalls}</td>
 									<td className="govuk-table__cell" >{hr.dateTimeRecorded?.split('T')[0]}</td>
 

--- a/src/gateways/call-types.js
+++ b/src/gateways/call-types.js
@@ -6,7 +6,7 @@ export class CallTypesGateway extends DefaultGateway {
             "All",
             "Help Request",
             "CEV",
-            "Welfare Call",
+            "Self Isolation",
             "Contact Tracing",
         ];
     }

--- a/src/pages/callback-list.js
+++ b/src/pages/callback-list.js
@@ -33,8 +33,11 @@ function CallbacksListPage({ callTypes }) {
     };
 
     const handleCallTypeChange = (event) => {
-        console.log(callTypes)
-        setDropdowns({ ...dropdowns, callType: event });
+        console.log(callTypes);
+        setDropdowns({
+            ...dropdowns,
+            callType: event == 'Self Isolation' ? 'Welfare Call' : event
+        });
     };
 
     const getCallHandlers = async () => {


### PR DESCRIPTION
Change the wording that's displayed for welfare calls to self isolation. This does not change how it's being saved in the backend. Places where this wording was changed:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/54268893/122903530-64126d00-d347-11eb-8c69-111622546636.png">
<img width="183" alt="image" src="https://user-images.githubusercontent.com/54268893/122903553-6aa0e480-d347-11eb-8d35-08433a12ed3b.png">
<img width="160" alt="image" src="https://user-images.githubusercontent.com/54268893/122903577-71c7f280-d347-11eb-9f9b-409b81051485.png">
<img width="519" alt="image" src="https://user-images.githubusercontent.com/54268893/122903602-77bdd380-d347-11eb-99a8-7c596f41f37e.png">
<img width="306" alt="image" src="https://user-images.githubusercontent.com/54268893/122903647-82786880-d347-11eb-877a-45df9d8bc71c.png">
<img width="336" alt="image" src="https://user-images.githubusercontent.com/54268893/122903675-8ad0a380-d347-11eb-94c3-418a843b9e7d.png">
<img width="187" alt="image" src="https://user-images.githubusercontent.com/54268893/122903793-a5a31800-d347-11eb-82a5-c6ee5b7ece6b.png">

