### PR TITLE
Fix/ticket validation

### DIFF
--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -179,6 +179,8 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         return helpNeeded !== 'CEV' || Object.values(cevHelpNeeds).includes(true);
     };
 
+    const isNonEmpty = (argument) => argument === false || argument ? true : false;
+
     const handleUpdate = async (event) => {
         event.preventDefault();
 
@@ -222,9 +224,10 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
             setErrorsExist(true);
         }
         else if (
-            (callMade == true && callOutcomeValues.length > 1 && callDirection != null && helpNeeded != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
+            isNonEmpty(helpNeeded) && isNonEmpty(callMade) && isNonEmpty(followUpRequired) &&
+            ((callMade == true && callOutcomeValues.length > 1 && callDirection != null && helpNeeded != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
             (callMade == false && helpNeeded && followUpRequired != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
-            (followUpRequired != null && caseNote !="" && helpNeeded != null && helpNeeded != "" && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText))
+            (followUpRequired != null && caseNote !="" && helpNeeded != null && helpNeeded != "" && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)))
         ) {
             setSubmitEnabled(false);
             saveFunction(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email);

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -180,8 +180,9 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
     };
 
     // Checks to see if the UI field was set (from null) to boolean (true, false) value, or if UI
-    // field was set to a Truthy value: from null, undefined or "" to "CEV", "Welfare", etc. 
-    const isBooleanOrTruthyValue = (uiFieldValue) => uiFieldValue === false || uiFieldValue ? true : false;
+    // field was set to a Truthy value: from null, undefined or "" to "CEV", "Welfare", etc.
+    const isBooleanOrTruthyValue = (uiFieldValue) =>
+        uiFieldValue === false || uiFieldValue ? true : false;
 
     const mandatoryFieldsWereGivenInput = () => {
         const supportTypeIsSelected = isBooleanOrTruthyValue(helpNeeded);
@@ -190,8 +191,13 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
 
         const whenNotHiddenCEVNeedsAreSelected = atLeast1CEVNeedsCheckboxIsSelected();
 
-        return supportTypeIsSelected && whetherTheCallWasMadeIsSelected && whetherTicketNeedsFollowUpIsSelected && whenNotHiddenCEVNeedsAreSelected;
-    }
+        return (
+            supportTypeIsSelected &&
+            whetherTheCallWasMadeIsSelected &&
+            whetherTicketNeedsFollowUpIsSelected &&
+            whenNotHiddenCEVNeedsAreSelected
+        );
+    };
 
     const handleUpdate = async (event) => {
         event.preventDefault();
@@ -234,9 +240,23 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         // jeez, this looks sooo fragile
         if (
             mandatoryFieldsWereGivenInput() &&
-            ((callMade == true && callOutcomeValues.length > 1 && callDirection != null && helpNeeded != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
-            (callMade == false && helpNeeded && followUpRequired != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
-            (followUpRequired != null && caseNote !="" && helpNeeded != null && helpNeeded != "" && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)))
+            ((callMade == true &&
+                callOutcomeValues.length > 1 &&
+                callDirection != null &&
+                helpNeeded != null &&
+                ((email != null && showEmail) || !showEmail) &&
+                ((phoneNumber != null && showText) || !showText)) ||
+                (callMade == false &&
+                    helpNeeded &&
+                    followUpRequired != null &&
+                    ((email != null && showEmail) || !showEmail) &&
+                    ((phoneNumber != null && showText) || !showText)) ||
+                (followUpRequired != null &&
+                    caseNote != '' &&
+                    helpNeeded != null &&
+                    helpNeeded != '' &&
+                    ((email != null && showEmail) || !showEmail) &&
+                    ((phoneNumber != null && showText) || !showText)))
         ) {
             setSubmitEnabled(false);
             saveFunction(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email);

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -179,7 +179,17 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         return helpNeeded !== 'CEV' || Object.values(cevHelpNeeds).includes(true);
     };
 
-    const isNonEmpty = (argument) => argument === false || argument ? true : false;
+    // Checks to see if the UI field was set (from null) to boolean (true, false) value, or if UI
+    // field was set to a Truthy value: from null, undefined or "" to "CEV", "Welfare", etc. 
+    const isBooleanOrTruthyValue = (uiFieldValue) => uiFieldValue === false || uiFieldValue ? true : false;
+
+    const mandatoryFieldsWereGivenInput = () => {
+        const supportTypeIsSelected = isBooleanOrTruthyValue(helpNeeded);
+        const whetherTheCallWasMadeIsSelected = isBooleanOrTruthyValue(callMade);
+        const whetherTicketNeedsFollowUpIsSelected = isBooleanOrTruthyValue(followUpRequired);
+
+        return supportTypeIsSelected && whetherTheCallWasMadeIsSelected && whetherTicketNeedsFollowUpIsSelected;
+    }
 
     const handleUpdate = async (event) => {
         event.preventDefault();
@@ -225,7 +235,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
             window.scrollTo(0, 0);
         }
         else if (
-            isNonEmpty(helpNeeded) && isNonEmpty(callMade) && isNonEmpty(followUpRequired) &&
+            mandatoryFieldsWereGivenInput() &&
             ((callMade == true && callOutcomeValues.length > 1 && callDirection != null && helpNeeded != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
             (callMade == false && helpNeeded && followUpRequired != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
             (followUpRequired != null && caseNote !="" && helpNeeded != null && helpNeeded != "" && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)))

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -174,8 +174,8 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         }
     };
 
-    const validateCEVNeedsFieldset = () => {
-        // at least 1 checkbox has to be selected
+    const atLeast1CEVNeedsCheckboxIsSelected = () => {
+        // Returns "false" only when helpNeeded = 'CEV' and 0 CEV needs checkboxes are selected.
         return helpNeeded !== 'CEV' || Object.values(cevHelpNeeds).includes(true);
     };
 
@@ -188,7 +188,9 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         const whetherTheCallWasMadeIsSelected = isBooleanOrTruthyValue(callMade);
         const whetherTicketNeedsFollowUpIsSelected = isBooleanOrTruthyValue(followUpRequired);
 
-        return supportTypeIsSelected && whetherTheCallWasMadeIsSelected && whetherTicketNeedsFollowUpIsSelected;
+        const whenNotHiddenCEVNeedsAreSelected = atLeast1CEVNeedsCheckboxIsSelected();
+
+        return supportTypeIsSelected && whetherTheCallWasMadeIsSelected && whetherTicketNeedsFollowUpIsSelected && whenNotHiddenCEVNeedsAreSelected;
     }
 
     const handleUpdate = async (event) => {
@@ -230,11 +232,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         }
 
         // jeez, this looks sooo fragile
-        if (!validateCEVNeedsFieldset()) {
-            setErrorsExist(true);
-            window.scrollTo(0, 0);
-        }
-        else if (
+        if (
             mandatoryFieldsWereGivenInput() &&
             ((callMade == true && callOutcomeValues.length > 1 && callDirection != null && helpNeeded != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||
             (callMade == false && helpNeeded && followUpRequired != null && ((email != null && showEmail) || !showEmail) && ((phoneNumber != null && showText) || !showText)) ||

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -222,6 +222,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         // jeez, this looks sooo fragile
         if (!validateCEVNeedsFieldset()) {
             setErrorsExist(true);
+            window.scrollTo(0, 0);
         }
         else if (
             isNonEmpty(helpNeeded) && isNonEmpty(callMade) && isNonEmpty(followUpRequired) &&
@@ -232,7 +233,8 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
             setSubmitEnabled(false);
             saveFunction(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email);
         } else {
-            setErrorsExist(true);
+            setErrorsExist(true); // generic error, user won't be told what's wrong.
+            window.scrollTo(0, 0);
         }
     };
 


### PR DESCRIPTION
# What:
- A quick fix to 'CallbackForm' validation for it to enforce mandatory fields
- JS scroll to the top of the page upon validation failure.
- Grouped some of the validation assertions by purpose into mandatory fields group.
- Formatted 'CallbackForm' validation code with Prettier to make it readable without having to scroll to the next galaxy horizontally.

# Why:
- Help Request Tickets that were accidentally created without supplying mandatory fields are causing issues to the users and the HR ticket's edit page layout.
- User is scrolled to the top of the page so that they would see the generic validation error message that would otherwise be missed.
- Other changes were done to make the 'CallbackForm' validation code more readable. It's a good starting point before doing any further refactoring of rest of that massive boolean expression. Refactoring of that is a priority right now because we'll have to add onto that validation logic soon by adding Self-Isolation call outcomes.

# Notes:
- Jira Ticket: [HTHD-22](https://hackney.atlassian.net/browse/HTHD-22?atlOrigin=eyJpIjoiNDJhOWRmYTlhNjZiNDhjODg0OGRmOGY4YWE4YjRhMTEiLCJwIjoiaiJ9).
- Mandatory fields validation function isn't complete yet. There still are fields that will have to be added to it in the future; however, to do so would require refactoring of ambiguous boolean expression.
- Validation & feedback on error are both areas touched by tech-debt requiring refactoring. Refactoring will be done in the future as part of another ticket.