### PR TITLE
Feature/self isolation needs

### DIFF
--- a/cypress/integration/journeys/add-self-isolation-needs.spec.js
+++ b/cypress/integration/journeys/add-self-isolation-needs.spec.js
@@ -1,0 +1,45 @@
+before(() => {
+    cy.login();
+    cy.setIntercepts();
+    cy.visit(`http://localhost:3000/dashboard`);
+    cy.get('[data-testid=view-callback-list_button]').click();
+    cy.get('[data-testid=callbacks-list-view_link-0]').click({ force: true });
+    cy.get('[data-testid=add-support-button]').click({ force: true });
+});
+
+
+context('When adding non self-isolation help request', () => {
+    it('it does not display the self-isolation needs form', () => {
+        cy.get('[data-testid=self-isolation-needs]').should('not.exist');
+
+        cy.get('[data-testid=call-type-radio-button]').eq(0).click({ force: true });
+        cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
+        cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
+        cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
+        cy.get('[data-testid=self-isolation-needs]').should('not.exist');
+    });
+});
+
+context('When adding new self isolation help request and call completed is selected', () => {
+    it('displays self isolation help needs form', () => {
+        cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
+        cy.get('[data-testid=self-isolation-needs]').should('not.exist');
+
+        cy.get('[data-testid=call-type-radio-button]').eq(2).click({ force: true });
+        cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
+        cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
+        cy.get('[data-testid=self-isolation-needs]').should('not.exist');
+
+        cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
+        cy.get('[data-testid=self-isolation-needs]').should('be.visible');
+    });
+});
+
+context('When required fields are not filled in', () => {
+    it('displays validation error', () => {
+        cy.get('[data-testid=callback-form-update_button]').click({ force: true });
+        cy.get('[data-testid=callback-form-validation-error]').should('be.visible');
+        cy.url().should('match', /\/add-support/);
+    });
+});
+

--- a/src/components/CallHistory/CallHistory.jsx
+++ b/src/components/CallHistory/CallHistory.jsx
@@ -12,8 +12,8 @@ export default function CaseNotes({ calls }) {
             .replace('wrong_number', 'Wrong number')
             .replace('no_answer_machine', 'No answer machine')
             .replace('food_consortia_referral_needs', 'The resident needed a referral to the food consortia')
-            .replace('other_support_needs', 'Other support needs')
-            .replace('no_support_needs', 'No needs')
+            .replace('other_support_needs', 'The resident had other support needs')
+            .replace('no_support_needs', 'The resident did not require support')
     };
 
     return (

--- a/src/components/CallHistory/CallHistory.jsx
+++ b/src/components/CallHistory/CallHistory.jsx
@@ -10,7 +10,10 @@ export default function CaseNotes({ calls }) {
             .replace('call_rescheduled', 'Call rescheduled')
             .replace('voicemail', 'Voicemail left')
             .replace('wrong_number', 'Wrong number')
-            .replace('no_answer_machine', 'No answer machine');
+            .replace('no_answer_machine', 'No answer machine')
+            .replace('food_consortia_referral_needs', 'The resident needed a referral to the food consortia')
+            .replace('other_support_needs', 'Other support needs')
+            .replace('no_support_needs', 'No needs')
     };
 
     return (

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -166,6 +166,15 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
             let newCallOutcomesValues = callOutcomeArray.filter(
                 (callOutcomeValue) => callOutcomeValue != value
             );
+            if (value == 'callback_complete'){
+                newCallOutcomesValues = newCallOutcomesValues.filter(
+                    (callOutcomeValue) => 
+                    callOutcomeValue != 'food_consortia_referral_needs' &&
+                    callOutcomeValue != 'other_support_needs' &&
+                    callOutcomeValue != 'no_support_needs'
+                );
+            }
+
             const callOutcomeString = newCallOutcomesValues.join();
             setCallOutcomeValues(callOutcomeString);
         } else {

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -88,6 +88,11 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         { name: 'Wrong number', value: 'wrong_number' },
         { name: 'No answer machine', value: 'no_answer_machine' }
     ];
+    const selfIsolationNeeds = [
+        { name: 'The resident needed a referral to the food consortia', value: 'food_consortia_referral_needs' },
+        { name: 'Other support needs', value: 'other_support_needs' },
+        { name: 'No needs', value: 'no_support_needs' }
+    ];
     const callTypes = ['Contact Tracing', 'CEV', 'Welfare Call', 'Help Request'];
     const followupRequired = ['Yes', 'No'];
     const whoMadeInitialContact = ['I called the resident', 'The resident called me'];
@@ -178,6 +183,16 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         // Returns "false" only when helpNeeded = 'CEV' and 0 CEV needs checkboxes are selected.
         return helpNeeded !== 'CEV' || Object.values(cevHelpNeeds).includes(true);
     };
+    const validateSelfIsolationNeedsFieldset = () => {
+        return callOutcomeValues.includes('callback_complete') &&
+                helpNeeded === 'Welfare Call' &&
+                (callOutcomeValues.includes('food_consortia_referral_needs') ||
+                    callOutcomeValues.includes('other_support_needs') ||
+                    callOutcomeValues.includes('no_support_needs')) ||  
+                !callOutcomeValues.includes('callback_complete') ||
+                helpNeeded !== 'Welfare Call'
+        };
+    
 
     // Checks to see if the UI field was set (from null) to boolean (true, false) value, or if UI
     // field was set to a Truthy value: from null, undefined or "" to "CEV", "Welfare", etc.
@@ -239,7 +254,8 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
 
         // jeez, this looks sooo fragile
         if (
-            mandatoryFieldsWereGivenInput() &&
+            mandatoryFieldsWereGivenInput() && 
+            validateSelfIsolationNeedsFieldset() &&
             ((callMade == true &&
                 callOutcomeValues.length > 1 &&
                 callDirection != null &&
@@ -398,6 +414,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
                                             }}
                                             aria-controls="conditional-CallMade"
                                             aria-expanded="false"
+                                            data-testid="call-type-yes-radio-button"
                                         />
                                         <label
                                             className="govuk-label govuk-radios__label"
@@ -432,6 +449,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
                                                                 }}
                                                                 aria-controls="conditional-CallDetail"
                                                                 aria-expanded="false"
+                                                                data-testid="yes-spoke-to-resident"
                                                             />
                                                             <label
                                                                 className="govuk-label govuk-radios__label"
@@ -472,7 +490,8 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
                                                                                             aria-describedby="CallOutcome-hint"
                                                                                             onCheckboxChange={
                                                                                                 onCheckboxChangeUpdate
-                                                                                            }></Checkbox>
+                                                                                            }
+                                                                                            data-testid={`${spokeToResidentCallOutcome.value}-checkbox`}></Checkbox>
                                                                                     );
                                                                                 }
                                                                             )}
@@ -546,7 +565,38 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
                                                     </div>
                                                 </fieldset>
                                             </div>
-
+                                            {callOutcomeValues.includes('callback_complete') && helpNeeded == 'Welfare Call' &&
+                                            <div className="govuk-form-group lbh-form-group" data-testid="self-isolation-needs">
+                                                <fieldset className="govuk-fieldset">
+                                                    <legend className="govuk-fieldset__legend mandatoryQuestion">
+                                                        {' '}
+                                                        Did the resident require any support?{' '}
+                                                    </legend>
+                                                    {selfIsolationNeeds.map(
+                                                        (
+                                                            selfIsolationNeed
+                                                        ) => {
+                                                            return (
+                                                                <Checkbox
+                                                                    id={
+                                                                        selfIsolationNeed.name
+                                                                    }
+                                                                    name="selfIsolationNeeds"
+                                                                    type="checkbox"
+                                                                    value={
+                                                                        selfIsolationNeed.value
+                                                                    }
+                                                                    label={
+                                                                        selfIsolationNeed.name
+                                                                    }
+                                                                    onCheckboxChange={
+                                                                        onCheckboxChangeUpdate
+                                                                    }></Checkbox>
+                                                            );
+                                                        }
+                                                    )}
+                                                </fieldset>
+                                            </div>}
                                             <div className="govuk-form-group lbh-form-group">
                                                 <fieldset className="govuk-fieldset">
                                                     <legend className="govuk-fieldset__legend mandatoryQuestion">

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -89,9 +89,9 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
         { name: 'No answer machine', value: 'no_answer_machine' }
     ];
     const selfIsolationNeeds = [
-        { name: 'The resident needed a referral to the food consortia', value: 'food_consortia_referral_needs' },
-        { name: 'Other support needs', value: 'other_support_needs' },
-        { name: 'No needs', value: 'no_support_needs' }
+        { name: 'Yes, the resident needed a referral to the food consortia', value: 'food_consortia_referral_needs' },
+        { name: 'Yes, the resident had other support needs', value: 'other_support_needs' },
+        { name: 'No, the resident did not require support', value: 'no_support_needs' }
     ];
     const callTypes = ['Contact Tracing', 'CEV', 'Welfare Call', 'Help Request'];
     const followupRequired = ['Yes', 'No'];

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -162,7 +162,7 @@ export default function CallbackForm({residentId, resident, helpRequest, backHre
 
     const onCheckboxChangeUpdate = (value) => {
         if (callOutcomeValues.includes(value)) {
-            const callOutcomeArray = callOutcomeValues.split();
+            const callOutcomeArray = callOutcomeValues.split(',');
             let newCallOutcomesValues = callOutcomeArray.filter(
                 (callOutcomeValue) => callOutcomeValue != value
             );

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -12,7 +12,10 @@ export const callOutcomes = {
     call_rescheduled: 'Call rescheduled',
     voicemail: 'Voicemail left',
     wrong_number: 'Wrong number',
-    no_answer_machine: 'No answer machine'
+    no_answer_machine: 'No answer machine',
+    food_consortia_referral_needs: 'The resident needed a referral to the food consortia',
+    other_support_needs: 'Other support needs',
+    no_support_needs: 'No needs'
 };
 
 export const helpTypes = [ALL, WELFARE_CALL, HELP_REQUEST, CONTACT_TRACING, CEV];

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -13,9 +13,9 @@ export const callOutcomes = {
     voicemail: 'Voicemail left',
     wrong_number: 'Wrong number',
     no_answer_machine: 'No answer machine',
-    food_consortia_referral_needs: 'The resident needed a referral to the food consortia',
-    other_support_needs: 'Other support needs',
-    no_support_needs: 'No needs'
+    food_consortia_referral_needs: 'Yes, the resident needed a referral to the food consortia',
+    other_support_needs: 'Yes, the resident had other support needs',
+    no_support_needs: 'No, the resident did not require support'
 };
 
 export const helpTypes = [ALL, WELFARE_CALL, HELP_REQUEST, CONTACT_TRACING, CEV];


### PR DESCRIPTION
**What**
Add support needs question for the self isolation calls.
`Did the resident require any support?` would only appear when `self-isolation` call type and `callback completed` is selected. The question would also be mandatory.
Logged answer would appear as part of outcomes for the call.
![image](https://user-images.githubusercontent.com/54268893/123393094-ac26cf00-d595-11eb-9a2e-b65d87fc7c92.png)
![image](https://user-images.githubusercontent.com/54268893/123393115-afba5600-d595-11eb-8c08-09b763dabcac.png)

**Why**
To enable reporting on these needs

**Ticket**
[HTHD-18](https://hackney.atlassian.net/browse/HTHD-18)