### PR TITLE
Remove default all call types

### DIFF
--- a/cypress/integration/journeys/assing-calls.spec.js
+++ b/cypress/integration/journeys/assing-calls.spec.js
@@ -23,6 +23,7 @@ describe('As a call handler I can bulk assign calls', () => {
         });
 
         it('Assign button should route to Callbacks list page', () => {
+            cy.get('[data-testid=assign-call-type_dropdown]').select('All');
             cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
             cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
@@ -45,14 +46,43 @@ describe('As a call handler I can bulk assign calls', () => {
     });
 
     context('Assign call has validation', () => {
-        it('does not let you assign calls unless assignment type and handlers areselected', () => {
+        it('does not let you assign calls if call type, assignment type and handlers are not selected', () => {
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
             cy.get('[data-testid=assign-call-validation-error]').should('be.visible');
-
+        });
+        it('does not let you assign calls if only an assignment type is selected', () => {
             cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
             cy.get('[data-testid=assign-call-validation-error]').should('be.visible');
+        });
 
+        it('does not let you assign calls if only a handler is selected', () => {
+            cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
+            cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
+            cy.get('[data-testid=assign-call-validation-error]').should('be.visible');
+        });
+
+        it('does not let you assign calls if only a call type is selected', () => {
+            cy.get('[data-testid=assign-call-type_dropdown]').select('All');
+            cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
+            cy.get('[data-testid=assign-call-validation-error]').should('be.visible');
+        });
+
+        it('does not let you assign calls if only a call type and assignment type are selected', () => {
+            cy.get('[data-testid=assign-call-type_dropdown]').select('All');
+            cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
+            cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
+            cy.get('[data-testid=assign-call-validation-error]').should('be.visible');
+        });
+
+        it('does not let you assign calls if only a call type and handlers are selected', () => {
+            cy.get('[data-testid=assign-call-type_dropdown]').select('All');
+            cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
+            cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
+            cy.get('[data-testid=assign-call-validation-error]').should('be.visible');
+        });
+
+        it('does not let you assign calls if only an assignment type and handlers are selected', () => {
             cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
             cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });

--- a/cypress/integration/journeys/assing-calls.spec.js
+++ b/cypress/integration/journeys/assing-calls.spec.js
@@ -1,3 +1,5 @@
+import { DEFAULT_DROPDOWN_OPTION } from '../../../src/helpers/constants';
+
 beforeEach(() => {
     cy.login();
     cy.setIntercepts();
@@ -35,7 +37,8 @@ describe('As a call handler I can bulk assign calls', () => {
         it('Call handlers are retrieved and mapped to dropdown options', () => {
             cy.get('[data-testid=assign-call-type_dropdown]')
                 .find('option')
-                .should('have.length', 6);
+                .should('have.length', 6)
+                .should('have.value', DEFAULT_DROPDOWN_OPTION);
             cy.get('[data-testid=assign-call-handler-checkbox]').should('have.length', 4);
         });
         it('Call types dropdown does not default to All', () => {

--- a/cypress/integration/journeys/assing-calls.spec.js
+++ b/cypress/integration/journeys/assing-calls.spec.js
@@ -34,8 +34,13 @@ describe('As a call handler I can bulk assign calls', () => {
         it('Call handlers are retrieved and mapped to dropdown options', () => {
             cy.get('[data-testid=assign-call-type_dropdown]')
                 .find('option')
-                .should('have.length', 5);
+                .should('have.length', 6);
             cy.get('[data-testid=assign-call-handler-checkbox]').should('have.length', 4);
+        });
+        it('Call types dropdown does not default to All', () => {
+            cy.get('[data-testid=assign-call-type_dropdown]')
+                .find('option')
+                .should('not.have.value', 'All');
         });
     });
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -5,6 +5,7 @@ export const CONTACT_TRACING = 'Contact Tracing';
 export const HELP_REQUEST = 'Help Request';
 export const WELFARE_CALL = 'Welfare Call';
 export const ALL = 'All';
+export const DEFAULT_DROPDOWN_OPTION = 'Please choose';
 
 export const callOutcomes = {
     callback_complete: 'Callback complete',
@@ -30,8 +31,7 @@ export const cevHelpTypes = {
     noNeedsIdentified: 'No needs identified'
 };
 
-export const TEST_AND_TRACE_FOLLOWUP_TEXT = 'test-and-trace-followup-text'
-export const TEST_AND_TRACE_FOLLOWUP_EMAIL = 'test-and-trace-followup-email'
-export const PRE_CALL_MESSAGE_TEMPLATE = 'pre-call-message-template'
-export const SELF_ISOLATION_PRE_CALL_MESSAGE_TEMPLATE = 'self-isolation-pre-call-message-template'
-
+export const TEST_AND_TRACE_FOLLOWUP_TEXT = 'test-and-trace-followup-text';
+export const TEST_AND_TRACE_FOLLOWUP_EMAIL = 'test-and-trace-followup-email';
+export const PRE_CALL_MESSAGE_TEMPLATE = 'pre-call-message-template';
+export const SELF_ISOLATION_PRE_CALL_MESSAGE_TEMPLATE = 'self-isolation-pre-call-message-template';

--- a/src/pages/assign-calls.js
+++ b/src/pages/assign-calls.js
@@ -7,7 +7,7 @@ import { CallHandlerGateway } from '../gateways/call-handler';
 import { CallbackGateway } from '../gateways/callback';
 import { HelpRequestGateway } from '../gateways/help-request';
 import { useRouter } from 'next/router';
-import { callTypes } from '../helpers/constants';
+import { callTypes, DEFAULT_DROPDOWN_OPTION } from '../helpers/constants';
 
 export default function AssignCallsPage() {
     const router = useRouter();
@@ -31,7 +31,7 @@ export default function AssignCallsPage() {
     useEffect(getCallHandlers, []);
 
     useEffect(() => {
-        setDropDownItems(['Please choose'].concat(callTypes));
+        setDropDownItems([DEFAULT_DROPDOWN_OPTION].concat(callTypes));
     }, []);
 
     const updateSelectedCallHandlers = (value) => {
@@ -64,7 +64,7 @@ export default function AssignCallsPage() {
             selectedAssignment.length == 0 ||
             selectedCallHandlers.length == 0 ||
             selectedCallType == '' ||
-            selectedCallType == 'Please choose'
+            selectedCallType == DEFAULT_DROPDOWN_OPTION
         ) {
             setErrorsExist(true);
         } else {

--- a/src/pages/assign-calls.js
+++ b/src/pages/assign-calls.js
@@ -13,7 +13,8 @@ export default function AssignCallsPage() {
     const router = useRouter();
     const [callHandlers, setCallHandlers] = useState([]);
     const [selectedCallHandlers, setSelectedCallHandlers] = useState([]);
-    const [selectedCallType, setSelectedCallType] = useState('All');
+    const [dropdownItems, setDropDownItems] = useState(['']);
+    const [selectedCallType, setSelectedCallType] = useState('');
     const [selectedAssignment, setSelectedAssignment] = useState([]);
     const [errorsExist, setErrorsExist] = useState(null);
 
@@ -28,6 +29,10 @@ export default function AssignCallsPage() {
     };
 
     useEffect(getCallHandlers, []);
+
+    useEffect(() => {
+        setDropDownItems(['Please choose'].concat(callTypes));
+    }, []);
 
     const updateSelectedCallHandlers = (value) => {
         if (selectedCallHandlers.includes(value)) {
@@ -169,7 +174,7 @@ export default function AssignCallsPage() {
                 <div className="govuk-!-margin-bottom-5">
                     <label className="govuk-label">Call types</label>
                     <Dropdown
-                        dropdownItems={callTypes}
+                        dropdownItems={dropdownItems}
                         onChange={(type) => {
                             setSelectedCallType(type);
                         }}

--- a/src/pages/assign-calls.js
+++ b/src/pages/assign-calls.js
@@ -172,7 +172,11 @@ export default function AssignCallsPage() {
                 </h1>
 
                 <div className="govuk-!-margin-bottom-5">
-                    <label className="govuk-label">Call types</label>
+                    <h3
+                        className="govuk-heading-m"
+                        style={{ marginRight: '1em', marginLeft: '.2em', marginTop: '2em' }}>
+                        Call types
+                    </h3>
                     <Dropdown
                         dropdownItems={dropdownItems}
                         onChange={(type) => {

--- a/src/pages/assign-calls.js
+++ b/src/pages/assign-calls.js
@@ -59,13 +59,17 @@ export default function AssignCallsPage() {
         return assignmentCount;
     };
 
+    const formIsValid = () => {
+        return (
+            selectedAssignment.length > 0 &&
+            selectedCallHandlers.length > 0 &&
+            selectedCallType != '' &&
+            selectedCallType != DEFAULT_DROPDOWN_OPTION
+        );
+    };
+
     const handleAssign = async (event) => {
-        if (
-            selectedAssignment.length == 0 ||
-            selectedCallHandlers.length == 0 ||
-            selectedCallType == '' ||
-            selectedCallType == DEFAULT_DROPDOWN_OPTION
-        ) {
+        if (!formIsValid()) {
             setErrorsExist(true);
         } else {
             let callbacks = await callbackGateway.getCallback({});

--- a/src/pages/assign-calls.js
+++ b/src/pages/assign-calls.js
@@ -60,7 +60,12 @@ export default function AssignCallsPage() {
     };
 
     const handleAssign = async (event) => {
-        if (selectedAssignment.length == 0 || selectedCallHandlers.length == 0) {
+        if (
+            selectedAssignment.length == 0 ||
+            selectedCallHandlers.length == 0 ||
+            selectedCallType == '' ||
+            selectedCallType == 'Please choose'
+        ) {
             setErrorsExist(true);
         } else {
             let callbacks = await callbackGateway.getCallback({});
@@ -172,11 +177,11 @@ export default function AssignCallsPage() {
                 </h1>
 
                 <div className="govuk-!-margin-bottom-5">
-                    <h3
-                        className="govuk-heading-m"
+                    <p
+                        className="govuk-heading-m mandatoryQuestion"
                         style={{ marginRight: '1em', marginLeft: '.2em', marginTop: '2em' }}>
                         Call types
-                    </h3>
+                    </p>
                     <Dropdown
                         dropdownItems={dropdownItems}
                         onChange={(type) => {

--- a/src/pages/send-bulk-message.js
+++ b/src/pages/send-bulk-message.js
@@ -6,109 +6,125 @@ import { Button, Checkbox, Dropdown } from '../components/Form';
 import { CallbackGateway } from '../gateways/callback';
 import { useRouter } from 'next/router';
 import {
-  PRE_CALL_MESSAGE_TEMPLATE,
-  SELF_ISOLATION_PRE_CALL_MESSAGE_TEMPLATE
+    PRE_CALL_MESSAGE_TEMPLATE,
+    SELF_ISOLATION_PRE_CALL_MESSAGE_TEMPLATE
 } from '../helpers/constants';
-import { GovNotifyGateway  } from "../gateways/gov-notify";
-import { unsafeExtractUser } from "../helpers/auth";
-import { callTypes, DEFAULT_DROPDOWN_OPTION } from "../helpers/constants";
+import { GovNotifyGateway } from '../gateways/gov-notify';
+import { unsafeExtractUser } from '../helpers/auth';
+import { callTypes, DEFAULT_DROPDOWN_OPTION } from '../helpers/constants';
 
 export default function AssignCallsPage() {
     const router = useRouter();
-		const user = unsafeExtractUser()
-    const [assignedCallbacks ,setAssignedCallbacks]  = useState(null)
-    const [unAssignedCallbacks ,setUnAssignedCallbacks]  = useState(null)
-    const [previewTemplate, setTemplatePreview] = useState([])
+    const user = unsafeExtractUser();
+    const [assignedCallbacks, setAssignedCallbacks] = useState(null);
+    const [unAssignedCallbacks, setUnAssignedCallbacks] = useState(null);
+    const [previewTemplate, setTemplatePreview] = useState([]);
     const [unassigned, setUnassigned] = useState({
-      value:false,
-      sendSms:false
-    })
+        value: false,
+        sendSms: false
+    });
     const [assigned, setAssigned] = useState({
-      value:false,
-      sendSms:false
-    })
-    const [helpType, setHelpTpye] = useState(null)
-    const [callbacks, setCallbacks] = useState(null)
-    const [dropdownItems, setDropDown] =  useState([""])
-    const [errorsExist, setErrorsExist] = useState(false)
+        value: false,
+        sendSms: false
+    });
+    const [helpType, setHelpTpye] = useState(null);
+    const [callbacks, setCallbacks] = useState(null);
+    const [dropdownItems, setDropDown] = useState(['']);
+    const [errorsExist, setErrorsExist] = useState(false);
     const getCallbacks = async () => {
-      const callbackGateway = new CallbackGateway();
-      let callbacks = await callbackGateway.getCallback({});
-      setCallbacks(callbacks)
-    }
-
-    const getPreview = async (value) => {
-      let govNotifyGateway = new GovNotifyGateway();
-      let response;
-      if (value == 'Welfare Call') {
-          response = await govNotifyGateway.getTemplatePreview(
-            SELF_ISOLATION_PRE_CALL_MESSAGE_TEMPLATE
-          );
-      } else {
-          response = await govNotifyGateway.getTemplatePreview(PRE_CALL_MESSAGE_TEMPLATE);
-      }
-      setTemplatePreview(response.body);
-  };
-
-    useEffect(()=> {
-      getPreview()
-    }, [])
-    useEffect(()=> {
-      getCallbacks()
-    }, [])
-    useEffect(()=>{
-      setDropDown([DEFAULT_DROPDOWN_OPTION].concat(callTypes))
-    }, [])
-    
-
-    const handleSend = async (event) => {
-      if((assigned.value || unassigned.value) && helpType){
-        event.preventDefault();
-        let govNotifyGateway = new GovNotifyGateway
-        const textTemplateId = helpType == 'Welfare Call' ? SELF_ISOLATION_PRE_CALL_MESSAGE_TEMPLATE : PRE_CALL_MESSAGE_TEMPLATE;
-        await govNotifyGateway.sendBulkText(JSON.stringify({assigned:assigned, unassigned: unassigned, user:user.name, helpType: helpType, textTemplateId}))
-        router.push('/dashboard');
-      }else{
-        setErrorsExist(true)
-      }
+        const callbackGateway = new CallbackGateway();
+        let callbacks = await callbackGateway.getCallback({});
+        setCallbacks(callbacks);
     };
 
-    const updateSendTextMessageCases = (value) =>{
-      if (value == 'unassigned'){
-        let unassignedObject = (unassigned.value) ? {value: false, sendSms: false } : { value: true, sendSms: true}
-        setUnassigned(unassignedObject)
-        
-      } else if (value == 'assigned'){
-        let assignedObject = (assigned.value) ? {value: false, sendSms: false } : {value: true,sendSms: true }
-        setAssigned(assignedObject)
-      }
-    }
+    const getPreview = async (value) => {
+        let govNotifyGateway = new GovNotifyGateway();
+        let response;
+        if (value == 'Welfare Call') {
+            response = await govNotifyGateway.getTemplatePreview(
+                SELF_ISOLATION_PRE_CALL_MESSAGE_TEMPLATE
+            );
+        } else {
+            response = await govNotifyGateway.getTemplatePreview(PRE_CALL_MESSAGE_TEMPLATE);
+        }
+        setTemplatePreview(response.body);
+    };
+
+    useEffect(() => {
+        getPreview();
+    }, []);
+    useEffect(() => {
+        getCallbacks();
+    }, []);
+    useEffect(() => {
+        setDropDown([DEFAULT_DROPDOWN_OPTION].concat(callTypes));
+    }, []);
+
+    const handleSend = async (event) => {
+        if ((assigned.value || unassigned.value) && helpType) {
+            event.preventDefault();
+            let govNotifyGateway = new GovNotifyGateway();
+            const textTemplateId =
+                helpType == 'Welfare Call'
+                    ? SELF_ISOLATION_PRE_CALL_MESSAGE_TEMPLATE
+                    : PRE_CALL_MESSAGE_TEMPLATE;
+            await govNotifyGateway.sendBulkText(
+                JSON.stringify({
+                    assigned: assigned,
+                    unassigned: unassigned,
+                    user: user.name,
+                    helpType: helpType,
+                    textTemplateId
+                })
+            );
+            router.push('/dashboard');
+        } else {
+            setErrorsExist(true);
+        }
+    };
+
+    const updateSendTextMessageCases = (value) => {
+        if (value == 'unassigned') {
+            let unassignedObject = unassigned.value
+                ? { value: false, sendSms: false }
+                : { value: true, sendSms: true };
+            setUnassigned(unassignedObject);
+        } else if (value == 'assigned') {
+            let assignedObject = assigned.value
+                ? { value: false, sendSms: false }
+                : { value: true, sendSms: true };
+            setAssigned(assignedObject);
+        }
+    };
 
     const updateHelpType = (value) => {
-      setHelpTpye(value)
-      let unassignedCallbacks = [];
-      let assignedCallbacks = [];
-      callbacks.forEach((callback) => {
-        if (callback.assignedTo == null && callback.callType == value || !callback.assignedTo && callback.callType == value ) {
-          unassignedCallbacks.push(callback);
-      } else if(callback.callType == value ) {
-          assignedCallbacks.push(callback);
-      } else if(value == 'All'){
-        if (callback.assignedTo == null || !callback.assignedTo) {
-          unassignedCallbacks.push(callback);
-        } else {
-          assignedCallbacks.push(callback);
-        }
-      }
-      });
-      setAssignedCallbacks(assignedCallbacks);
-      setUnAssignedCallbacks(unassignedCallbacks);
-      getPreview(value)
-    }
+        setHelpTpye(value);
+        let unassignedCallbacks = [];
+        let assignedCallbacks = [];
+        callbacks.forEach((callback) => {
+            if (
+                (callback.assignedTo == null && callback.callType == value) ||
+                (!callback.assignedTo && callback.callType == value)
+            ) {
+                unassignedCallbacks.push(callback);
+            } else if (callback.callType == value) {
+                assignedCallbacks.push(callback);
+            } else if (value == 'All') {
+                if (callback.assignedTo == null || !callback.assignedTo) {
+                    unassignedCallbacks.push(callback);
+                } else {
+                    assignedCallbacks.push(callback);
+                }
+            }
+        });
+        setAssignedCallbacks(assignedCallbacks);
+        setUnAssignedCallbacks(unassignedCallbacks);
+        getPreview(value);
+    };
 
     return (
         <Layout>
-      {errorsExist && (
+            {errorsExist && (
                 <div
                     className="govuk-error-summary"
                     aria-labelledby="error-summary-title"
@@ -121,9 +137,7 @@ export default function AssignCallsPage() {
                     </h2>
                     <div className="govuk-error-summary__body">
                         <ul className="govuk-list govuk-error-summary__list">
-                            <li>
-                                You have not completed the form
-                            </li>
+                            <li>You have not completed the form</li>
                         </ul>
                     </div>
                 </div>
@@ -140,76 +154,67 @@ export default function AssignCallsPage() {
                     Send bulk message
                 </h1>
                 <p
-                      className="govuk-heading-m mandatoryQuestion"
-                      style={{ marginRight: '1em', marginLeft: '.2em', marginTop: '2em' }}>
-                      Please select a help type
-                  </p>
-              <Dropdown
-                dropdownItems={dropdownItems}
-                onChange={updateHelpType}
-                selected="help type"
-                date-testid="bulk-message-dropdown"
-              >
+                    className="govuk-heading-m mandatoryQuestion"
+                    style={{ marginRight: '1em', marginLeft: '.2em', marginTop: '2em' }}>
+                    Please select a help type
+                </p>
+                <Dropdown
+                    dropdownItems={dropdownItems}
+                    onChange={updateHelpType}
+                    selected="help type"
+                    date-testid="bulk-message-dropdown"></Dropdown>
+                <br />
+                {helpType && (
+                    <div className="govuk-!-margin-bottom-5">
+                        <h3
+                            className="govuk-heading-m mandatoryQuestion"
+                            style={{ marginRight: '1em', marginLeft: '.2em', marginTop: '2em' }}>
+                            Send text to
+                        </h3>
+                        <div className="govuk-checkboxes  lbh-checkboxes">
+                            <Checkbox
+                                key="unassigned-cases-checkbox"
+                                label="Unassigned cases"
+                                value="unassigned"
+                                onCheckboxChange={updateSendTextMessageCases}
+                            />
 
-              </Dropdown>
-              <br/>
-              {
-                helpType &&
+                            {unassigned.value && (
+                                <div className="govuk-inset-text">
+                                    Approximately {unAssignedCallbacks.length} unnasigned
+                                </div>
+                            )}
+                            <br />
 
-                <div className="govuk-!-margin-bottom-5">
-          
-                  <h3
-                      className="govuk-heading-m mandatoryQuestion"
-                      style={{ marginRight: '1em', marginLeft: '.2em', marginTop: '2em' }}>
-                      Send text to
-                  </h3>
-                  <div className="govuk-checkboxes  lbh-checkboxes">
-                      <Checkbox
-                          key="unassigned-cases-checkbox"
-                          label="Unassigned cases"
-                          value="unassigned"
-                          onCheckboxChange={updateSendTextMessageCases}
-                      />
+                            <Checkbox
+                                key="assigned-cases-checkbox"
+                                label="Assigned cases"
+                                value="assigned"
+                                onCheckboxChange={updateSendTextMessageCases}
+                                data-testid="assigned-send-bulk-checkbox"
+                            />
 
-                      {
-                        unassigned.value && 
-                          <div className="govuk-inset-text">
-                            Approximately {unAssignedCallbacks.length} unnasigned
-                          </div>
-                      }
-                      <br/>
+                            {assigned.value && (
+                                <div className="govuk-inset-text">
+                                    Approximately {assignedCallbacks.length} assigned
+                                </div>
+                            )}
+                            <br />
+                        </div>
+                    </div>
+                )}
+                <br />
+                <h3 className="govuk-heading-m"> Text content</h3>
+                <div className="govuk-inset-text">{previewTemplate}</div>
 
-                      <Checkbox
-                          key="assigned-cases-checkbox"
-                          label="Assigned cases"
-                          value="assigned"
-                          onCheckboxChange={updateSendTextMessageCases}
-                          data-testid="assigned-send-bulk-checkbox"
-                      />
-
-                      {
-                        assigned.value && 
-                          <div className="govuk-inset-text">
-                            Approximately {assignedCallbacks.length} assigned
-                          </div>
-                      }
-                      <br/>
-
-                  </div>
-                  </div>
-                }
-                  <br/>
-                  <h3 className="govuk-heading-m"> Text content</h3>
-                  <div className="govuk-inset-text">{previewTemplate}</div>
-
-                  <br></br>
+                <br></br>
                 <div className="govuk-grid-row" id="btn-bottom-panel">
                     <div className="govuk-grid-column-one-half">
                         <Button
                             text="Send"
                             addClass="govuk-!-margin-right-1"
                             onClick={(event) => {
-                              handleSend(event);
+                                handleSend(event);
                             }}
                             data-testid="send-bulk-message_button"
                         />

--- a/src/pages/send-bulk-message.js
+++ b/src/pages/send-bulk-message.js
@@ -11,7 +11,7 @@ import {
 } from '../helpers/constants';
 import { GovNotifyGateway  } from "../gateways/gov-notify";
 import { unsafeExtractUser } from "../helpers/auth";
-import { callTypes } from "../helpers/constants";
+import { callTypes, DEFAULT_DROPDOWN_OPTION } from "../helpers/constants";
 
 export default function AssignCallsPage() {
     const router = useRouter();
@@ -57,7 +57,7 @@ export default function AssignCallsPage() {
       getCallbacks()
     }, [])
     useEffect(()=>{
-      setDropDown(["Please choose"].concat(callTypes))
+      setDropDown([DEFAULT_DROPDOWN_OPTION].concat(callTypes))
     }, [])
     
 


### PR DESCRIPTION
**What**
Have changed the default option for 'Call type' in the 'Assign calls' form so nothing is selected by default.
![image](https://user-images.githubusercontent.com/32848419/132514340-0914e1eb-aa13-4958-9865-03be863d2650.png)

**Why**
There have been instances where all call types have been assigned to call handlers incorrectly. This change is being made so that all call types won't be assigned by default

**Anything Else**
Have copied the structure from the Send group text or email form:
* Have made the default option 'Please choose'
* Have made the Call type drop-down mandatory
* Have ensured that there is validation so the form can't be submitted without choosing a call type