### PR TITLE
Improve Assign Calls usabiity

### DIFF
--- a/cypress/integration/journeys/assing-calls.spec.js
+++ b/cypress/integration/journeys/assing-calls.spec.js
@@ -25,7 +25,7 @@ describe('As a call handler I can bulk assign calls', () => {
         });
 
         it('Assign button should route to Callbacks list page', () => {
-            cy.get('[data-testid=assign-call-type_dropdown]').select('All');
+            cy.get('[data-testid=call-type-checkbox]').first().click({ force: true });
             cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
             cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
@@ -34,17 +34,11 @@ describe('As a call handler I can bulk assign calls', () => {
     });
 
     context('Assign call page displays and maps data correctly', () => {
-        it('Call handlers are retrieved and mapped to dropdown options', () => {
-            cy.get('[data-testid=assign-call-type_dropdown]')
-                .find('option')
-                .should('have.length', 6)
-                .should('have.value', DEFAULT_DROPDOWN_OPTION);
+        it('Call handlers are retrieved and mapped to checkboxes', () => {
+            cy.get('[data-testid=call-type-checkbox]')
+                .should('have.length', 4)
+                .should('not.have.value', DEFAULT_DROPDOWN_OPTION);
             cy.get('[data-testid=assign-call-handler-checkbox]').should('have.length', 4);
-        });
-        it('Call types dropdown does not default to All', () => {
-            cy.get('[data-testid=assign-call-type_dropdown]')
-                .find('option')
-                .should('not.have.value', 'All');
         });
     });
 
@@ -66,20 +60,20 @@ describe('As a call handler I can bulk assign calls', () => {
         });
 
         it('does not let you assign calls if only a call type is selected', () => {
-            cy.get('[data-testid=assign-call-type_dropdown]').select('All');
+            cy.get('[data-testid=call-type-checkbox]').first().click({ force: true });
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
             cy.get('[data-testid=assign-call-validation-error]').should('be.visible');
         });
 
         it('does not let you assign calls if only a call type and assignment type are selected', () => {
-            cy.get('[data-testid=assign-call-type_dropdown]').select('All');
+            cy.get('[data-testid=call-type-checkbox]').first().click({ force: true });
             cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
             cy.get('[data-testid=assign-call-validation-error]').should('be.visible');
         });
 
         it('does not let you assign calls if only a call type and handlers are selected', () => {
-            cy.get('[data-testid=assign-call-type_dropdown]').select('All');
+            cy.get('[data-testid=call-type-checkbox]').first().click({ force: true });
             cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
             cy.get('[data-testid=assign-call-validation-error]').should('be.visible');

--- a/src/components/Form/Checkboxes/Checkbox.jsx
+++ b/src/components/Form/Checkboxes/Checkbox.jsx
@@ -11,7 +11,9 @@ const Checkbox = ({ label, isSelected, onCheckboxChange, value, containerStyle, 
             className="govuk-checkboxes__input"
             {...others}
         />
-        <label className="govuk-label govuk-checkboxes__label">{label}</label>
+        <label className="govuk-label govuk-checkboxes__label">
+            {label == 'Welfare Call' ? 'Self Isolation' : label}
+        </label>
     </div>
 );
 

--- a/src/components/Form/Checkboxes/Checkbox.jsx
+++ b/src/components/Form/Checkboxes/Checkbox.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-const Checkbox = ({ label, isSelected, onCheckboxChange, value, ...others }) => (
-    <div className="govuk-checkboxes__item">
-        <input 
+const Checkbox = ({ label, isSelected, onCheckboxChange, value, containerStyle, ...others }) => (
+    <div className="govuk-checkboxes__item" style={containerStyle}>
+        <input
             type="checkbox"
             label={label}
             checked={isSelected}
@@ -11,9 +11,7 @@ const Checkbox = ({ label, isSelected, onCheckboxChange, value, ...others }) => 
             className="govuk-checkboxes__input"
             {...others}
         />
-        <label className="govuk-label govuk-checkboxes__label">
-        {label}
-        </label>
+        <label className="govuk-label govuk-checkboxes__label">{label}</label>
     </div>
 );
 


### PR DESCRIPTION
**What**
- Improved clarity of header text.
- Change call types to a checkbox list.
- Made call handler list alphabetically ordered columns.

![image](https://user-images.githubusercontent.com/80220779/133068301-85fbbc4d-3353-445e-9b83-5d514132ebe3.png)

**Why**

It's a known problem that calls are sometimes assigned incorrectly to call handlers. We believe this is due to the usability / clarity of functionality on the assign calls page. In order to make it clearer what each form item is for, we've made the header text more descriptive.

To improve usability, call types are now a multi-select checkbox list. They default to none selected.