### PR TITLE
Remove EUSS option from new support request

### DIFF
--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -114,8 +114,8 @@ export default function CallbackForm({
         'CEV',
         'Welfare Call',
         'Help Request',
-        'Link Work',
-        ...(IS_EUSS_ENABLED ? ['EUSS'] : [])
+        'Link Work'
+        // ...(IS_EUSS_ENABLED ? ['EUSS'] : [])
     ];
     const followupRequired = ['Yes', 'No'];
     const whoMadeInitialContact = ['I called the resident', 'The resident called me'];

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -8,7 +8,7 @@ export const ALL = 'All';
 export const LINK_WORK = 'Link Work';
 export const EUSS = 'EUSS';
 export const DEFAULT_DROPDOWN_OPTION = 'Please choose';
-export const IS_EUSS_ENABLED = process.env.APP_STAGE !== 'production';
+export const IS_EUSS_ENABLED = false;
 
 export const callOutcomes = {
     callback_complete: 'Callback complete',


### PR DESCRIPTION
**What**
* Remove the EUSS call type from the create new support form
* Set the IS_EUSS_ENABLED constant to false

![image](https://user-images.githubusercontent.com/32848419/133459808-f42ab0c3-c7e9-4421-abd9-684df811e806.png)

**Why**
* We want to ensure no one logs an EUSS call type before the permissions are set up