### PR TITLE
Add a help type parameter based on google group membership.

### DIFF
--- a/src/pages/api/proxy/[...path].js
+++ b/src/pages/api/proxy/[...path].js
@@ -2,13 +2,23 @@ import { authoriseUser } from '../../../helpers/auth';
 import { HereToHelpApiGateway } from '../../../gateways/here-to-help-api-gateway';
 
 const hereToHelpApiGateway = new HereToHelpApiGateway();
+const eussGroup = 'Here To Help EUSS Outbound Calls';
+const eussType = 'EUSS';
+const includeHelpTypeParam = 'includeType';
+
+const authoriseQuery = (req, user) => {
+    let query = req.query;
+    if (user.groups.includes(eussGroup) && req.method == 'GET')
+        query[includeHelpTypeParam] = eussType;
+    return query;
+};
 
 const endpoint = async (req, res) => {
     const user = authoriseUser(req);
     if (!user) return res.status(401).json({ error: 'Unauthorised' });
 
     try {
-        const { path, ...queryParams } = req.query;
+        const { path, ...queryParams } = authoriseQuery(req, user);
         const { status, data } = await hereToHelpApiGateway.request(
             path,
             req.method,

--- a/src/pages/api/proxy/[...path].js
+++ b/src/pages/api/proxy/[...path].js
@@ -8,7 +8,7 @@ const includeHelpTypeParam = 'includeType';
 
 const authoriseQuery = (req, user) => {
     let query = req.query;
-    if (user.groups.includes(eussGroup) && req.method == 'GET')
+    if (user.groups?.includes(eussGroup) && req.method == 'GET')
         query[includeHelpTypeParam] = eussType;
     return query;
 };


### PR DESCRIPTION
**What**

If a user belongs to a specified group a parameter will be passed (server-to-server) from the API proxy to the source API for Here To Help. This will include data that's relevant to them.

**Why**

New help types may not be applicable to all users, this is the first step in allowing us to separate help types based on user groups.

**Anything else?**

This solution needs adaptation and some changes to support multiple groups/help types. We should also consider all filtering occurring within the source API.