### PR TITLE
Show call types relevant to authenticated user

### DIFF
--- a/cypress/integration/journeys/add-euss.spec.js
+++ b/cypress/integration/journeys/add-euss.spec.js
@@ -12,6 +12,9 @@ beforeEach(() => {
 
 context('When adding new EUSS help request and call completed is selected', () => {
     it('does not display self isolation help needs form and form can be submitted', () => {
+        cy.server();
+        cy.route('GET', '/api/proxy/help-types').as('getHelpTypes');
+        cy.wait('@getHelpTypes', { timeout: 10000});
         cy.get('[data-testid=call-type-radio-button]').eq(5).should('have.value', EUSS);
         cy.get('[data-testid=call-type-radio-button]').eq(5).click({ force: true });
         cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
@@ -35,6 +38,9 @@ context('When required fields are not filled in', () => {
     });
 
     it('displays validation error when call completed but no follow up selected', () => {
+        cy.server();
+        cy.route('GET', '/api/proxy/help-types').as('getHelpTypes');
+        cy.wait('@getHelpTypes', { timeout: 10000});
         cy.get('[data-testid=call-type-radio-button]').eq(5).click({ force: true });
         cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
         cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
@@ -48,6 +54,9 @@ context('When required fields are not filled in', () => {
 context('When EUSS is not enabled', () => {
     it('does not display EUSS call type option', () => {
         cy.login();
+        cy.server();
+        cy.route('GET', '/api/proxy/help-types').as('getHelpTypes');
+        cy.wait('@getHelpTypes', { timeout: 10000});
         cy.get('[data-testid=call-type-radio-button]').last().should('not.have.value', EUSS);
         cy.get('[data-testid=call-type-radio-button]').should('not.contain.value', EUSS);
     });

--- a/cypress/integration/journeys/add-euss.spec.js
+++ b/cypress/integration/journeys/add-euss.spec.js
@@ -1,7 +1,8 @@
-import { EUSS, IS_EUSS_ENABLED } from '../../../src/helpers/constants';
+import { EUSS } from '../../../src/helpers/constants';
+import { EUSS_User } from '../../support/commands';
 
 beforeEach(() => {
-    cy.login();
+    cy.login(EUSS_User);
     cy.setIntercepts();
     cy.visit(`http://localhost:3000/dashboard`);
     cy.get('[data-testid=view-callback-list_button]').click();
@@ -9,47 +10,45 @@ beforeEach(() => {
     cy.get('[data-testid=add-support-button]').click({ force: true });
 });
 
-if (IS_EUSS_ENABLED) {
-    context('When adding new EUSS help request and call completed is selected', () => {
-        it('does not display self isolation help needs form and form can be submitted', () => {
-            cy.get('[data-testid=call-type-radio-button]').eq(5).should('have.value', EUSS);
-            cy.get('[data-testid=call-type-radio-button]').eq(5).click({ force: true });
-            cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
-            cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
-            cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
-            cy.get('[data-testid=self-isolation-needs]').should('not.exist');
+context('When adding new EUSS help request and call completed is selected', () => {
+    it('does not display self isolation help needs form and form can be submitted', () => {
+        cy.get('[data-testid=call-type-radio-button]').eq(5).should('have.value', EUSS);
+        cy.get('[data-testid=call-type-radio-button]').eq(5).click({ force: true });
+        cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
+        cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
+        cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
+        cy.get('[data-testid=self-isolation-needs]').should('not.exist');
 
-            cy.get('[data-testid=call-direction-radio-button]').first().click({ force: true });
-            cy.get('[data-testid=followup-required-radio-button]').first().click({ force: true });
-            cy.get('[data-testid=callback-form-update_button]').click({ force: true });
+        cy.get('[data-testid=call-direction-radio-button]').first().click({ force: true });
+        cy.get('[data-testid=followup-required-radio-button]').first().click({ force: true });
+        cy.get('[data-testid=callback-form-update_button]').click({ force: true });
 
-            cy.get('[data-testid=callback-form-validation-error]').should('not.exist');
-        });
+        cy.get('[data-testid=callback-form-validation-error]').should('not.exist');
+    });
+});
+
+context('When required fields are not filled in', () => {
+    it('displays validation error if form is submitted with no inputs', () => {
+        cy.get('[data-testid=callback-form-update_button]').click({ force: true });
+        cy.get('[data-testid=callback-form-validation-error]').should('be.visible');
+        cy.url().should('match', /\/add-support/);
     });
 
-    context('When required fields are not filled in', () => {
-        it('displays validation error if form is submitted with no inputs', () => {
-            cy.get('[data-testid=callback-form-update_button]').click({ force: true });
-            cy.get('[data-testid=callback-form-validation-error]').should('be.visible');
-            cy.url().should('match', /\/add-support/);
-        });
+    it('displays validation error when call completed but no follow up selected', () => {
+        cy.get('[data-testid=call-type-radio-button]').eq(5).click({ force: true });
+        cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
+        cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
+        cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
+        cy.get('[data-testid=call-direction-radio-button]').first().click({ force: true });
+        cy.get('[data-testid=callback-form-update_button]').click({ force: true });
+        cy.get('[data-testid=callback-form-validation-error]').should('be.visible');
+    });
+});
 
-        it('displays validation error when call completed but no follow up selected', () => {
-            cy.get('[data-testid=call-type-radio-button]').eq(5).click({ force: true });
-            cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
-            cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
-            cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
-            cy.get('[data-testid=call-direction-radio-button]').first().click({ force: true });
-            cy.get('[data-testid=callback-form-update_button]').click({ force: true });
-            cy.get('[data-testid=callback-form-validation-error]').should('be.visible');
-        });
+context('When EUSS is not enabled', () => {
+    it('does not display EUSS call type option', () => {
+        cy.login();
+        cy.get('[data-testid=call-type-radio-button]').last().should('not.have.value', EUSS);
+        cy.get('[data-testid=call-type-radio-button]').should('not.contain.value', EUSS);
     });
-}
-if (!IS_EUSS_ENABLED) {
-    context('When EUSS is not enabled', () => {
-        it('does not display EUSS call type option', () => {
-            cy.get('[data-testid=call-type-radio-button]').last().should('not.have.value', EUSS);
-            cy.get('[data-testid=call-type-radio-button]').should('not.contain.value', EUSS);
-        });
-    });
-}
+});

--- a/cypress/integration/journeys/assing-calls.spec.js
+++ b/cypress/integration/journeys/assing-calls.spec.js
@@ -1,4 +1,5 @@
-import { DEFAULT_DROPDOWN_OPTION, EUSS, IS_EUSS_ENABLED } from '../../../src/helpers/constants';
+import { DEFAULT_DROPDOWN_OPTION, EUSS } from '../../../src/helpers/constants';
+import { EUSS_User } from '../../support/commands';
 
 beforeEach(() => {
     cy.login();
@@ -31,31 +32,28 @@ describe('As a call handler I can bulk assign calls', () => {
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
             cy.url().should('match', /\/callback-list$/);
         });
-        if (IS_EUSS_ENABLED) {
-            it('Can assign to EUSS call types when EUSS is enabled', () => {
-                cy.get('[data-testid=call-type-checkbox]')
-                    .should('have.length', 5)
-                    .eq(4)
-                    .should('have.value', EUSS);
-                cy.get('[data-testid=call-type-checkbox]').eq(4).click({ force: true });
-                cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
-                cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
-                cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
-            });
-        }
-        if (!IS_EUSS_ENABLED) {
-            it('Can not assign to EUSS call types when EUSS is disabled ', () => {
-                cy.get('[data-testid=call-type-checkbox]')
-                    .should('have.length', 4)
-                    .should('not.have.value', EUSS);
-            });
-        }
+        it('Can assign to EUSS call types when logged in as EUSS user', () => {
+            cy.login(EUSS_User);
+            cy.get('[data-testid=call-type-checkbox]')
+                .should('have.length', 5)
+                .eq(4)
+                .should('have.value', EUSS);
+            cy.get('[data-testid=call-type-checkbox]').eq(4).click({ force: true });
+            cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
+            cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
+            cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
+        });
+        it('Can not assign to EUSS call types when EUSS is disabled ', () => {
+            cy.get('[data-testid=call-type-checkbox]')
+                .should('have.length', 4)
+                .should('not.have.value', EUSS);
+        });
     });
 
     context('Assign call page displays and maps data correctly', () => {
         it('Call handlers are retrieved and mapped to checkboxes', () => {
             cy.get('[data-testid=call-type-checkbox]')
-                .should('have.length', IS_EUSS_ENABLED ? 5 : 4)
+                .should('have.length', 4)
                 .should('not.have.value', DEFAULT_DROPDOWN_OPTION);
             cy.get('[data-testid=assign-call-handler-checkbox]').should('have.length', 4);
         });

--- a/cypress/integration/pages/callbacks-list.spec.js
+++ b/cypress/integration/pages/callbacks-list.spec.js
@@ -1,4 +1,5 @@
 import { EUSS, IS_EUSS_ENABLED } from '../../../src/helpers/constants';
+import { EUSS_User } from '../../support/commands';
 
 beforeEach(() => {
     cy.login();
@@ -8,14 +9,12 @@ beforeEach(() => {
 describe('Callbacks list page displays and maps data correctly', () => {
     it('Callbacks are retrieved and mapped to table rows', () => {
         cy.visit('/callback-list');
-        cy.get('[data-testid=callbacks-table_row]').should('have.length', 8);
+        cy.get('[data-testid=callbacks-table_row]').should('have.length', 7);
     });
 
     it('Help types are mapped to help case type dropdown options', () => {
         cy.visit('/callback-list');
-        cy.get('[data-testid=help-type-dropdown]')
-            .find('option')
-            .should('have.length', IS_EUSS_ENABLED === true ? 7 : 6);
+        cy.get('[data-testid=help-type-dropdown]').find('option').should('have.length', 6);
     });
 
     it('Call handlers are mapped to call handlers dropdown options', () => {
@@ -46,15 +45,20 @@ describe('Callbacks list page filters callbacks correctly', () => {
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '3');
         cy.get('[data-testid=help-type-dropdown]').select('Link Work');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
-        if (IS_EUSS_ENABLED) {
-            cy.get('[data-testid=help-type-dropdown]').select(EUSS);
-            cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
-        }
+    });
+
+    it('Can filter by EUSS when logged in as the EUSS user', () => {
+        cy.login(EUSS_User);
+        cy.visit('/callback-list');
+        cy.get('[data-testid=callbacks-table_row]').should('have.length', '8');
+        cy.get('[data-testid=help-type-dropdown]').find('option').should('have.length', 6);
+        cy.get('[data-testid=help-type-dropdown]').select(EUSS);
+        cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
     });
 
     it('Upon selecting Call Handlers dropdown value, callbacks get filtered by that value', () => {
         cy.visit('/callback-list');
-        cy.get('[data-testid=callbacks-table_row]').should('have.length', '8');
+        cy.get('[data-testid=callbacks-table_row]').should('have.length', '7');
         cy.get('[data-testid=call-handlers-dropdown]').select('Person A');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '2');
         cy.get('[data-testid=call-handlers-dropdown]').select('Person B');
@@ -80,14 +84,10 @@ describe('Navigating Away from Callbacks list page', () => {
     });
 });
 
-if (!IS_EUSS_ENABLED) {
-    describe('When EUSS is not enabled', () => {
-        it('the callback list does not filter by EUSS', () => {
-            cy.visit('/callback-list');
-            cy.get('[data-testid=help-type-dropdown]').find('option').should('have.length', 6);
-            cy.get('[data-testid=help-type-dropdown]')
-                .find('option')
-                .should('not.have.value', EUSS);
-        });
+describe('When EUSS is not enabled', () => {
+    it('the callback list does not filter by EUSS', () => {
+        cy.visit('/callback-list');
+        cy.get('[data-testid=help-type-dropdown]').find('option').should('have.length', 6);
+        cy.get('[data-testid=help-type-dropdown]').find('option').should('not.have.value', EUSS);
     });
-}
+});

--- a/cypress/integration/pages/callbacks-list.spec.js
+++ b/cypress/integration/pages/callbacks-list.spec.js
@@ -9,12 +9,12 @@ beforeEach(() => {
 describe('Callbacks list page displays and maps data correctly', () => {
     it('Callbacks are retrieved and mapped to table rows', () => {
         cy.visit('/callback-list');
-        cy.get('[data-testid=callbacks-table_row]').should('have.length', 7);
+        cy.get('[data-testid=callbacks-table_row]').should('have.length', 8);
     });
 
     it('Help types are mapped to help case type dropdown options', () => {
         cy.visit('/callback-list');
-        cy.get('[data-testid=help-type-dropdown]').find('option').should('have.length', 6);
+        cy.get('[data-testid=help-type-dropdown]').find('option').should('have.length', 7);
     });
 
     it('Call handlers are mapped to call handlers dropdown options', () => {
@@ -47,18 +47,9 @@ describe('Callbacks list page filters callbacks correctly', () => {
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
     });
 
-    it('Can filter by EUSS when logged in as the EUSS user', () => {
-        cy.login(EUSS_User);
-        cy.visit('/callback-list');
-        cy.get('[data-testid=callbacks-table_row]').should('have.length', '8');
-        cy.get('[data-testid=help-type-dropdown]').find('option').should('have.length', 6);
-        cy.get('[data-testid=help-type-dropdown]').select(EUSS);
-        cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
-    });
-
     it('Upon selecting Call Handlers dropdown value, callbacks get filtered by that value', () => {
         cy.visit('/callback-list');
-        cy.get('[data-testid=callbacks-table_row]').should('have.length', '7');
+        cy.get('[data-testid=callbacks-table_row]').should('have.length', '8');
         cy.get('[data-testid=call-handlers-dropdown]').select('Person A');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '2');
         cy.get('[data-testid=call-handlers-dropdown]').select('Person B');
@@ -81,13 +72,5 @@ describe('Navigating Away from Callbacks list page', () => {
         cy.visit('/callback-list');
         cy.get('[data-testid=callbacks-list-view_link-0]').click({ force: true });
         cy.url().should('match', /\/helpcase-profile\/\d+$/);
-    });
-});
-
-describe('When EUSS is not enabled', () => {
-    it('the callback list does not filter by EUSS', () => {
-        cy.visit('/callback-list');
-        cy.get('[data-testid=help-type-dropdown]').find('option').should('have.length', 6);
-        cy.get('[data-testid=help-type-dropdown]').find('option').should('not.have.value', EUSS);
     });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,5 +1,10 @@
 import jwt from 'jsonwebtoken';
-import {TEST_AND_TRACE_FOLLOWUP_TEXT, TEST_AND_TRACE_FOLLOWUP_EMAIL, PRE_CALL_MESSAGE_TEMPLATE} from '../../src/helpers/constants'
+import {
+    TEST_AND_TRACE_FOLLOWUP_TEXT,
+    TEST_AND_TRACE_FOLLOWUP_EMAIL,
+    PRE_CALL_MESSAGE_TEMPLATE,
+    EUSS_GROUP
+} from '../../src/helpers/constants';
 
 Cypress.Commands.add('getBySel', (selector, ...args) => {
     return cy.get(`[data-cy=${selector}]`, ...args);
@@ -14,7 +19,7 @@ export const defaultUser = {
 export const EUSS_User = {
     email: 'test@hackney.gov.uk',
     name: 'EUSS Test User',
-    groups: ['development-team-staging', 'Here To Help EUSS Outbound Calls']
+    groups: ['development-team-staging', EUSS_GROUP]
 };
 
 Cypress.Commands.add('login', (userData) => {
@@ -113,21 +118,32 @@ Cypress.Commands.add('setIntercepts', () => {
         fixture: 'residents/3/resident'
     });
 
-    cy.intercept('GET', `/api/proxy/gov-notify/previewTemplate?templateType=${TEST_AND_TRACE_FOLLOWUP_EMAIL}`, {
-        fixture: 'getEmailPreviewSuccessResponse'
-    });
+    cy.intercept(
+        'GET',
+        `/api/proxy/gov-notify/previewTemplate?templateType=${TEST_AND_TRACE_FOLLOWUP_EMAIL}`,
+        {
+            fixture: 'getEmailPreviewSuccessResponse'
+        }
+    );
 
-    cy.intercept('GET', `/api/proxy/gov-notify/previewTemplate?templateType=${TEST_AND_TRACE_FOLLOWUP_TEXT}`, {
-        fixture: 'getTextPreviewSuccessResponse'
-    });
+    cy.intercept(
+        'GET',
+        `/api/proxy/gov-notify/previewTemplate?templateType=${TEST_AND_TRACE_FOLLOWUP_TEXT}`,
+        {
+            fixture: 'getTextPreviewSuccessResponse'
+        }
+    );
 
-    cy.intercept('GET', `/api/proxy/gov-notify/previewTemplate?templateType=${PRE_CALL_MESSAGE_TEMPLATE}`, {
-        fixture: 'getBulkTextPreviewSuccessResponse'
-    });
+    cy.intercept(
+        'GET',
+        `/api/proxy/gov-notify/previewTemplate?templateType=${PRE_CALL_MESSAGE_TEMPLATE}`,
+        {
+            fixture: 'getBulkTextPreviewSuccessResponse'
+        }
+    );
 
     cy.intercept('POST', `/api/proxy/gov-notify/send-bulk-message`, {
-        statusCode: 200, 
-        body:{}
+        statusCode: 200,
+        body: {}
     });
-
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,6 +11,12 @@ export const defaultUser = {
     groups: ['development-team-staging']
 };
 
+export const EUSS_User = {
+    email: 'test@hackney.gov.uk',
+    name: 'EUSS Test User',
+    groups: ['development-team-staging', process.env.NEXT_PUBLIC_EUSS_GOOGLE_GROUP]
+};
+
 Cypress.Commands.add('login', (userData) => {
     if (userData === void 0) {
         userData = defaultUser;
@@ -21,6 +27,7 @@ Cypress.Commands.add('login', (userData) => {
     console.error(cookieName);
     console.error(jwtSecret);
     console.error('Yup');
+    console.log('user', userData.name);
 
     const token = jwt.sign(userData, jwtSecret);
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -14,7 +14,7 @@ export const defaultUser = {
 export const EUSS_User = {
     email: 'test@hackney.gov.uk',
     name: 'EUSS Test User',
-    groups: ['development-team-staging', process.env.NEXT_PUBLIC_EUSS_GOOGLE_GROUP]
+    groups: ['development-team-staging', 'Here To Help EUSS Outbound Calls']
 };
 
 Cypress.Commands.add('login', (userData) => {

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -11,6 +11,7 @@ import {
 import { useRouter } from 'next/router';
 import { GovNotifyGateway } from '../../gateways/gov-notify';
 import styles from '../CallbackForm/CallbackForm.module.scss';
+import { AuthorisedCallTypesGateway } from '../../gateways/authorised-call-types';
 
 export default function CallbackForm({
     residentId,
@@ -37,6 +38,13 @@ export default function CallbackForm({
     const [showEmail, setShowEmail] = useState(false);
     const [showText, setShowText] = useState(false);
     const [submitEnabled, setSubmitEnabled] = useState(true);
+    const [callTypes, setCallTypes] = useState([
+        'Contact Tracing',
+        'CEV',
+        'Welfare Call',
+        'Help Request',
+        'Link Work'
+    ]);
 
     const [errors, setErrors] = useState({
         CallbackRequired: null,
@@ -109,19 +117,13 @@ export default function CallbackForm({
         { name: 'Yes, the resident had other support needs', value: 'other_support_needs' },
         { name: 'No, the resident did not require support', value: 'no_support_needs' }
     ];
-    const callTypes = [
-        'Contact Tracing',
-        'CEV',
-        'Welfare Call',
-        'Help Request',
-        'Link Work'
-        // ...(IS_EUSS_ENABLED ? ['EUSS'] : [])
-    ];
+
     const followupRequired = ['Yes', 'No'];
     const whoMadeInitialContact = ['I called the resident', 'The resident called me'];
 
     useEffect(async () => {
         const govNotifyGateway = new GovNotifyGateway();
+        const authorisedCallTypesGateway = new AuthorisedCallTypesGateway();
 
         try {
             let textTemplate = await govNotifyGateway.getTemplatePreview(
@@ -137,6 +139,9 @@ export default function CallbackForm({
                 console.log('emailTemplate', emailTemplate);
                 setEmailTemplatePreview(emailTemplate.body);
             }
+
+            let authCallTypes = await authorisedCallTypesGateway.getCallTypes();
+            setCallTypes(authCallTypes);
         } catch (err) {
             console.log(`Error fetching themplates: ${err}`);
         }

--- a/src/gateways/authorised-call-types.js
+++ b/src/gateways/authorised-call-types.js
@@ -8,7 +8,7 @@ export class AuthorisedCallTypesGateway extends DefaultGateway {
 
     async getCallTypes() {
         let authorisedTypes = await this.getAuthorisedHelpTypes();
-        return ['Help Request', 'CEV', 'Self Isolation', 'Contact Tracing', 'Link Work'].concat(
+        return ['Contact Tracing', 'CEV', 'Welfare Call', 'Help Request', 'Link Work'].concat(
             authorisedTypes
         );
     }

--- a/src/gateways/authorised-call-types.js
+++ b/src/gateways/authorised-call-types.js
@@ -1,0 +1,15 @@
+import { DefaultGateway } from '../gateways/default-gateway';
+
+export class AuthorisedCallTypesGateway extends DefaultGateway {
+    async getAuthorisedHelpTypes() {
+        const response = await this.getFromUrl(`help-types`);
+        return response;
+    }
+
+    async getCallTypes() {
+        let authorisedTypes = await this.getAuthorisedHelpTypes();
+        return ['Help Request', 'CEV', 'Self Isolation', 'Contact Tracing', 'Link Work'].concat(
+            authorisedTypes
+        );
+    }
+}

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -9,6 +9,7 @@ export const LINK_WORK = 'Link Work';
 export const EUSS = 'EUSS';
 export const DEFAULT_DROPDOWN_OPTION = 'Please choose';
 export const IS_EUSS_ENABLED = true;
+export const EUSS_GROUP = 'Here To Help EUSS Outbound Calls';
 
 export const callOutcomes = {
     callback_complete: 'Callback complete',

--- a/src/pages/api/proxy/[...path].js
+++ b/src/pages/api/proxy/[...path].js
@@ -1,14 +1,14 @@
 import { authoriseUser } from '../../../helpers/auth';
 import { HereToHelpApiGateway } from '../../../gateways/here-to-help-api-gateway';
+import { EUSS_GROUP } from '../../../helpers/constants';
 
 const hereToHelpApiGateway = new HereToHelpApiGateway();
-const eussGroup = 'Here To Help EUSS Outbound Calls';
 const eussType = 'EUSS';
 const includeHelpTypeParam = 'includeType';
 
 const authoriseQuery = (req, user) => {
     let query = req.query;
-    if (user.groups?.includes(eussGroup) && req.method == 'GET')
+    if (user.groups?.includes(EUSS_GROUP) && req.method == 'GET')
         query[includeHelpTypeParam] = eussType;
     return query;
 };

--- a/src/pages/api/proxy/help-types.js
+++ b/src/pages/api/proxy/help-types.js
@@ -1,0 +1,18 @@
+import { authoriseUser } from '../../../helpers/auth';
+
+const endpoint = async (req, res) => {
+    const user = authoriseUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorised' });
+
+    try {
+        let response = [];
+        if (user?.groups.includes('Here To Help EUSS Outbound Calls')) response.push('EUSS');
+
+        return res.json(response);
+    } catch (err) {
+        console.log('Error: ' + err);
+        res.json({ error: `Server error` });
+    }
+};
+
+export default endpoint;

--- a/src/pages/api/proxy/help-types.js
+++ b/src/pages/api/proxy/help-types.js
@@ -1,4 +1,5 @@
 import { authoriseUser } from '../../../helpers/auth';
+import { EUSS_GROUP } from '../../../helpers/constants';
 
 const endpoint = async (req, res) => {
     const user = authoriseUser(req);
@@ -6,7 +7,7 @@ const endpoint = async (req, res) => {
 
     try {
         let response = [];
-        if (user?.groups.includes('Here To Help EUSS Outbound Calls')) response.push('EUSS');
+        if (user?.groups.includes(EUSS_GROUP)) response.push('EUSS');
 
         return res.json(response);
     } catch (err) {

--- a/src/pages/assign-calls.js
+++ b/src/pages/assign-calls.js
@@ -7,7 +7,8 @@ import { CallHandlerGateway } from '../gateways/call-handler';
 import { CallbackGateway } from '../gateways/callback';
 import { HelpRequestGateway } from '../gateways/help-request';
 import { useRouter } from 'next/router';
-import { callTypes, ALL } from '../helpers/constants';
+import { AuthorisedCallTypesGateway } from '../gateways/authorised-call-types';
+import { LINK_WORK } from '../helpers/constants';
 
 export default function AssignCallsPage() {
     const router = useRouter();
@@ -17,7 +18,6 @@ export default function AssignCallsPage() {
     const [selectedCallTypes, setSelectedCallTypes] = useState([]);
     const [selectedAssignment, setSelectedAssignment] = useState([]);
     const [errorsExist, setErrorsExist] = useState(null);
-
     const callbackGateway = new CallbackGateway();
     const gateway = new HelpRequestGateway();
 
@@ -30,8 +30,10 @@ export default function AssignCallsPage() {
 
     useEffect(getCallHandlers, []);
 
-    useEffect(() => {
-        setFilteredCallTypes(callTypes.filter((x) => x != ALL));
+    useEffect(async () => {
+        const authorisedCallTypesGateway = new AuthorisedCallTypesGateway();
+        let authCallTypes = await authorisedCallTypesGateway.getCallTypes();
+        setFilteredCallTypes(authCallTypes.filter((x) => x != LINK_WORK));
     }, []);
 
     const updateSelectedCallHandlers = (value) => {


### PR DESCRIPTION
**What**

Removed EUSS front-end functionality based on google group membership.

**Why**

This functionality is only relevant for a specific group of call handlers.

**Anything else**

We've targeted the priority areas where data is changed or added for EUSS as other groups can't see this data. Some filter options remain but will always show as empty for non-EUSS groups if selected.