### PR TITLE
Add link work assign calls

### DIFF
--- a/cypress/integration/journeys/assing-calls.spec.js
+++ b/cypress/integration/journeys/assing-calls.spec.js
@@ -35,8 +35,8 @@ describe('As a call handler I can bulk assign calls', () => {
         it('Can assign to EUSS call types when logged in as EUSS user', () => {
             cy.login(EUSS_User);
             cy.get('[data-testid=call-type-checkbox]')
-                .should('have.length', 5)
-                .eq(4)
+                .should('have.length', 6)
+                .eq(5)
                 .should('have.value', EUSS);
             cy.get('[data-testid=call-type-checkbox]').eq(4).click({ force: true });
             cy.get('[data-testid=assign-call-handler-checkbox]').first().click({ force: true });
@@ -45,7 +45,7 @@ describe('As a call handler I can bulk assign calls', () => {
         });
         it('Can not assign to EUSS call types when EUSS is disabled ', () => {
             cy.get('[data-testid=call-type-checkbox]')
-                .should('have.length', 4)
+                .should('have.length', 5)
                 .should('not.have.value', EUSS);
         });
     });
@@ -53,7 +53,7 @@ describe('As a call handler I can bulk assign calls', () => {
     context('Assign call page displays and maps data correctly', () => {
         it('Call handlers are retrieved and mapped to checkboxes', () => {
             cy.get('[data-testid=call-type-checkbox]')
-                .should('have.length', 4)
+                .should('have.length', 5)
                 .should('not.have.value', DEFAULT_DROPDOWN_OPTION);
             cy.get('[data-testid=assign-call-handler-checkbox]').should('have.length', 4);
         });

--- a/cypress/integration/journeys/assing-calls.spec.js
+++ b/cypress/integration/journeys/assing-calls.spec.js
@@ -43,7 +43,7 @@ describe('As a call handler I can bulk assign calls', () => {
             cy.get('[data-testid=assign-call-assigned-checkbox]').click({ force: true });
             cy.get('[data-testid=assign-call-assign_button]').click({ force: true });
         });
-        it('Can not assign to EUSS call types when EUSS is disabled ', () => {
+        it('Can not assign to EUSS call types when a non-EUSS user is logged in', () => {
             cy.get('[data-testid=call-type-checkbox]')
                 .should('have.length', 5)
                 .should('not.have.value', EUSS);

--- a/src/pages/assign-calls.js
+++ b/src/pages/assign-calls.js
@@ -8,7 +8,6 @@ import { CallbackGateway } from '../gateways/callback';
 import { HelpRequestGateway } from '../gateways/help-request';
 import { useRouter } from 'next/router';
 import { AuthorisedCallTypesGateway } from '../gateways/authorised-call-types';
-import { LINK_WORK } from '../helpers/constants';
 
 export default function AssignCallsPage() {
     const router = useRouter();
@@ -33,7 +32,7 @@ export default function AssignCallsPage() {
     useEffect(async () => {
         const authorisedCallTypesGateway = new AuthorisedCallTypesGateway();
         let authCallTypes = await authorisedCallTypesGateway.getCallTypes();
-        setFilteredCallTypes(authCallTypes.filter((x) => x != LINK_WORK));
+        setFilteredCallTypes(authCallTypes);
     }, []);
 
     const updateSelectedCallHandlers = (value) => {


### PR DESCRIPTION
**What**
* Added Link Work to the assign calls page
* Updated tests

![image](https://user-images.githubusercontent.com/32848419/134374384-5ce11f8e-2e81-4a20-a70c-f899db15fd1c.png)


**Why**
* Link work calls will need to be assigned to call handlers so this will allow for this

**Anything Else**
* Renamed one test
* We need to check if more call handlers need to be added for Link Work call types