### PR TITLE
Code tidy

### DIFF
--- a/cypress/integration/journeys/add-euss.spec.js
+++ b/cypress/integration/journeys/add-euss.spec.js
@@ -60,7 +60,7 @@ context('When required fields are not filled in', () => {
     });
 });
 
-context('When EUSS is not enabled', () => {
+context('When a non-EUSS user is logged in', () => {
     it('does not display EUSS call type option', () => {
         cy.login();
         cy.server();

--- a/cypress/integration/pages/callbacks-list.spec.js
+++ b/cypress/integration/pages/callbacks-list.spec.js
@@ -1,5 +1,4 @@
-import { EUSS, IS_EUSS_ENABLED } from '../../../src/helpers/constants';
-import { EUSS_User } from '../../support/commands';
+import { EUSS } from '../../../src/helpers/constants';
 
 beforeEach(() => {
     cy.login();

--- a/cypress/integration/pages/callbacks-list.spec.js
+++ b/cypress/integration/pages/callbacks-list.spec.js
@@ -45,6 +45,8 @@ describe('Callbacks list page filters callbacks correctly', () => {
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '3');
         cy.get('[data-testid=help-type-dropdown]').select('Link Work');
         cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
+        cy.get('[data-testid=help-type-dropdown]').select(EUSS);
+        cy.get('[data-testid=callbacks-table_row]').should('have.length', '1');
     });
 
     it('Upon selecting Call Handlers dropdown value, callbacks get filtered by that value', () => {

--- a/cypress/integration/pages/helpcase-profile.spec.js
+++ b/cypress/integration/pages/helpcase-profile.spec.js
@@ -1,4 +1,4 @@
-import { EUSS, IS_EUSS_ENABLED } from '../../../src/helpers/constants';
+import { EUSS } from '../../../src/helpers/constants';
 
 beforeEach(() => {
     cy.login();
@@ -90,25 +90,15 @@ describe('View helpcase profile page', () => {
             .first()
             .should('contain', 'Link Work: *** CREATED ***');
     });
-    if (IS_EUSS_ENABLED) {
-        it('displays filtered EUSS case notes ordered by date', () => {
-            cy.visit(`http://localhost:3000/helpcase-profile/3`);
-            cy.get('[data-testid=select-dropdown]').select(EUSS, { force: true });
 
-            cy.get('[data-testid=case-note-entry]').should('have.length', 1);
-            cy.get('[data-testid=case-note-entry]').first().scrollIntoView();
-            cy.get('[data-testid=case-note-entry]').first().should('contain', 'by Frodo Baggins');
-            cy.get('[data-testid=case-note-entry]').first().should('contain', '2020-09-07');
-            cy.get('[data-testid=case-note-entry]')
-                .first()
-                .should('contain', 'EUSS: *** CREATED ***');
-        });
-    }
-    if (!IS_EUSS_ENABLED) {
-        it('does not display EUSS filter if EUSS is not enabled', () => {
-            cy.visit(`http://localhost:3000/helpcase-profile/3`);
-            cy.get('[data-testid=select-dropdown]').find('option').should('have.length', 6);
-            cy.get('[data-testid=select-dropdown]').find('option').should('not.have.value', EUSS);
-        });
-    }
+    it('displays filtered EUSS case notes ordered by date', () => {
+        cy.visit(`http://localhost:3000/helpcase-profile/3`);
+        cy.get('[data-testid=select-dropdown]').select(EUSS, { force: true });
+
+        cy.get('[data-testid=case-note-entry]').should('have.length', 1);
+        cy.get('[data-testid=case-note-entry]').first().scrollIntoView();
+        cy.get('[data-testid=case-note-entry]').first().should('contain', 'by Frodo Baggins');
+        cy.get('[data-testid=case-note-entry]').first().should('contain', '2020-09-07');
+        cy.get('[data-testid=case-note-entry]').first().should('contain', 'EUSS: *** CREATED ***');
+    });
 });

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -3,7 +3,6 @@ import { Checkbox, RadioButton, Button, SingleRadioButton } from '../Form';
 import Link from 'next/link';
 import {
     cevHelpTypes,
-    IS_EUSS_ENABLED,
     selfIsolationCallTypes,
     TEST_AND_TRACE_FOLLOWUP_TEXT,
     TEST_AND_TRACE_FOLLOWUP_EMAIL,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -32,14 +32,6 @@ export const helpTypes = [
     LINK_WORK,
     ...(IS_EUSS_ENABLED ? ['EUSS'] : [])
 ];
-export const callTypes = [
-    'All',
-    'Help Request',
-    'CEV',
-    'Welfare Call',
-    'Contact Tracing',
-    ...(IS_EUSS_ENABLED ? ['EUSS'] : [])
-];
 export const selfIsolationCallTypes = [WELFARE_CALL, CONTACT_TRACING];
 export const bulkMessageCallTypes = [WELFARE_CALL, CONTACT_TRACING, EUSS];
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -23,15 +23,7 @@ export const callOutcomes = {
     no_support_needs: 'No, the resident did not require support'
 };
 
-export const helpTypes = [
-    ALL,
-    WELFARE_CALL,
-    HELP_REQUEST,
-    CONTACT_TRACING,
-    CEV,
-    LINK_WORK,
-    ...(IS_EUSS_ENABLED ? ['EUSS'] : [])
-];
+export const helpTypes = [ALL, WELFARE_CALL, HELP_REQUEST, CONTACT_TRACING, CEV, LINK_WORK, EUSS];
 export const selfIsolationCallTypes = [WELFARE_CALL, CONTACT_TRACING];
 export const bulkMessageCallTypes = [WELFARE_CALL, CONTACT_TRACING, EUSS];
 

--- a/src/pages/reassign-call/[requestId]/index.js
+++ b/src/pages/reassign-call/[requestId]/index.js
@@ -17,6 +17,7 @@ export default function ReassignCalls() {
     const getCallHandlers = async () => {
         const gateway = new CallHandlerGateway();
         const callHandlerList = await gateway.getCallHandler();
+        callHandlerList.sort();
         callHandlerList.unshift(NOT_ASSIGNED);
         setCallHandlers(callHandlerList);
     };


### PR DESCRIPTION
**What**
* Renamed some tests as per comments on https://github.com/LBHackney-IT/coronavirus-here-to-help-frontend/pull/98/files
* Added one test back as per comment on https://github.com/LBHackney-IT/coronavirus-here-to-help-frontend/pull/98/files
* Fixed the help case profile tests so they didn't depend on IS_EUSS_ENABLED
* Removed unused IS_EUSS_ENABLED constants from files (some instances of this constant are still in use)
* Sorted the call handler list for the individual reassign page

**Why**
* The changes made were small code changes that improve the readability of the tests and code
* There is also a minor update to alphabetically sort the call handlers which was requested
