### PR TITLE
Add subtype to help request form

### DIFF
--- a/cypress/integration/journeys/add-link-work.spec.js
+++ b/cypress/integration/journeys/add-link-work.spec.js
@@ -36,7 +36,7 @@ context('When Link Work is the selected help type', () => {
             .find('option')
             .should('have.length', 2)
             .should('have.value', DEFAULT_DROPDOWN_OPTION);
-        cy.get('[data-testid=subtype-dropdown]').select(REPAIRS);
+        cy.get('[data-testid=subtype-dropdown]').select(REPAIRS, { force: true });
         cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
         cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
         cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });

--- a/cypress/integration/journeys/add-link-work.spec.js
+++ b/cypress/integration/journeys/add-link-work.spec.js
@@ -44,7 +44,6 @@ context('When Link Work is the selected help type', () => {
         cy.get('[data-testid=call-direction-radio-button]').first().click({ force: true });
         cy.get('[data-testid=followup-required-radio-button]').first().click({ force: true });
         cy.get('[data-testid=callback-form-update_button]').click({ force: true });
-
         cy.get('[data-testid=callback-form-validation-error]').should('not.exist');
     });
 });

--- a/cypress/integration/journeys/add-link-work.spec.js
+++ b/cypress/integration/journeys/add-link-work.spec.js
@@ -1,3 +1,5 @@
+import { DEFAULT_DROPDOWN_OPTION, REPAIRS } from '../../../src/helpers/constants';
+
 beforeEach(() => {
     cy.login();
     cy.setIntercepts();
@@ -23,6 +25,29 @@ context('When adding new link work help request and call completed is selected',
     });
 });
 
+context('When Link Work is the selected help type', () => {
+    it('displays the drop-down giving you the option to select a subtype', () => {
+        cy.get('[data-testid=call-type-radio-button]').eq(4).click({ force: true });
+        cy.get('[data-testid=subtype-dropdown]').should('exist');
+    });
+    it('should be possible to select the repairs subtype and submit the form', () => {
+        cy.get('[data-testid=call-type-radio-button]').eq(4).click({ force: true });
+        cy.get('[data-testid=subtype-dropdown]')
+            .find('option')
+            .should('have.length', 2)
+            .should('have.value', DEFAULT_DROPDOWN_OPTION);
+        cy.get('[data-testid=subtype-dropdown]').select(REPAIRS);
+        cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
+        cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
+        cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
+
+        cy.get('[data-testid=call-direction-radio-button]').first().click({ force: true });
+        cy.get('[data-testid=followup-required-radio-button]').first().click({ force: true });
+        cy.get('[data-testid=callback-form-update_button]').click({ force: true });
+
+        cy.get('[data-testid=callback-form-validation-error]').should('not.exist');
+    });
+});
 context('When required fields are not filled in', () => {
     it('displays validation error if form is submitted with no inputs', () => {
         cy.get('[data-testid=callback-form-update_button]').click({ force: true });

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -168,18 +168,20 @@ export default function CallbackForm({
         }
     };
 
+    const followUpRequiredFunction = (value) => {
+        setFollowupRequired(value);
+    };
+
     const callBackFunction = (value) => {
-        if (value == 'Yes' || value == 'No') {
-            setFollowupRequired(value);
-        }
         if (callTypes.includes(value)) {
             setHelpNeeded(value);
             setSubtypeDropdownValues(value);
         }
     };
 
-    const setSubtypeDropdownValues = (value) => {
-        const subtypes = authCallTypes.filter((callType) => callType.name == value)[0].subtypes;
+    const setSubtypeDropdownValues = (selectedCallType) => {
+        const subtypes = authCallTypes.filter((callType) => callType.name == selectedCallType)[0]
+            .subtypes;
         if (subtypes) {
             setSubTypesDropdown([DEFAULT_DROPDOWN_OPTION].concat(subtypes));
         } else {
@@ -446,7 +448,7 @@ export default function CallbackForm({
                                                     <fieldset className="govuk-fieldset">
                                                         <h3 className="govuk-heading-m">
                                                             {' '}
-                                                            Support required subtype
+                                                            {helpNeeded} Category
                                                         </h3>
 
                                                         <Dropdown
@@ -902,7 +904,7 @@ export default function CallbackForm({
                                 radioButtonItems={followupRequired}
                                 name="FollowUpRequired"
                                 optionalClass="govuk-radios--inline"
-                                onSelectOption={callBackFunction}
+                                onSelectOption={followUpRequiredFunction}
                                 data-testid="followup-required-radio-button"
                             />
                         </fieldset>

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -45,7 +45,7 @@ export default function CallbackForm({
     const [callTypes, setCallTypes] = useState([]);
     const [authCallTypes, setAuthCallTypes] = useState([]);
     const [subTypesDropdown, setSubTypesDropdown] = useState([]);
-    const [helpNeededSubtype, setHelpNeededSubtype] = useState([]);
+    const [helpNeededSubtype, setHelpNeededSubtype] = useState('');
 
     const [errors, setErrors] = useState({
         CallbackRequired: null,
@@ -294,7 +294,8 @@ export default function CallbackForm({
             callbackRequired: callbackRequired,
             initialCallbackCompleted: initialCallbackCompleted,
             dateTimeRecorded: new Date(),
-            helpNeeded: helpNeeded
+            helpNeeded: helpNeeded,
+            helpNeededSubtype: helpNeededSubtype
         };
 
         if (helpNeeded === 'CEV') {
@@ -333,7 +334,6 @@ export default function CallbackForm({
             setSubmitEnabled(false);
             saveFunction(
                 helpNeeded,
-                helpNeededSubtype,
                 callDirection,
                 callOutcomeValues,
                 helpRequestObject,
@@ -451,9 +451,9 @@ export default function CallbackForm({
 
                                                         <Dropdown
                                                             onChange={updateSubTypeSelection}
-                                                            dropdownItems={
-                                                                subTypesDropdown
-                                                            }></Dropdown>
+                                                            dropdownItems={subTypesDropdown}
+                                                            data-testid="subtype-dropdown"
+                                                        />
                                                     </fieldset>
                                                 )}
                                             </fieldset>

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -188,7 +188,7 @@ export default function CallbackForm({
     };
 
     const updateSubTypeSelection = (value) => {
-        setHelpNeededSubtype(value);
+        setHelpNeededSubtype(value === DEFAULT_DROPDOWN_OPTION ? '' : value);
     };
 
     const CallDirectionFunction = (value) => {

--- a/src/gateways/help-request-call.js
+++ b/src/gateways/help-request-call.js
@@ -4,7 +4,6 @@ import { CEV, SHIELDING } from '../helpers/constants';
 const ToPostHelpRequestCall = (hr) => {
     return JSON.stringify({
         CallType: hr.callType == CEV ? SHIELDING : hr.callType,
-        CallSubType: hr.callSubType,
         CallDirection: hr.callDirection,
         CallOutcome: hr.callOutcome,
         CallDateTime: hr.callDateTime,

--- a/src/gateways/help-request-call.js
+++ b/src/gateways/help-request-call.js
@@ -1,17 +1,21 @@
 import { DefaultGateway } from '../gateways/default-gateway';
-import {CEV, SHIELDING} from '../helpers/constants';
+import { CEV, SHIELDING } from '../helpers/constants';
 
 const ToPostHelpRequestCall = (hr) => {
-  return JSON.stringify({
-      CallType: (hr.callType == CEV) ? SHIELDING: hr.callType,
-			CallDirection: hr.callDirection,
-			CallOutcome: hr.callOutcome,
-			CallDateTime: hr.callDateTime,
-			CallHandler: hr.callHandler
-  })
-}
+    return JSON.stringify({
+        CallType: hr.callType == CEV ? SHIELDING : hr.callType,
+        CallSubType: hr.callSubType,
+        CallDirection: hr.callDirection,
+        CallOutcome: hr.callOutcome,
+        CallDateTime: hr.callDateTime,
+        CallHandler: hr.callHandler
+    });
+};
 export class HelpRequestCallGateway extends DefaultGateway {
     async postHelpRequestCall(helpRequestId, requestBody) {
-      return await this.postToUrl(`v3/help-requests/${helpRequestId}/calls`, ToPostHelpRequestCall(requestBody))
+        return await this.postToUrl(
+            `v3/help-requests/${helpRequestId}/calls`,
+            ToPostHelpRequestCall(requestBody)
+        );
     }
 }

--- a/src/gateways/help-request.js
+++ b/src/gateways/help-request.js
@@ -145,6 +145,7 @@ const ToPostHelpRequestBody = (hr) => {
         InitialCallbackCompleted: hr.initialCallbackCompleted,
         DateTimeRecorded: hr.dateTimeRecorded,
         HelpNeeded: hr.helpNeeded == CEV ? SHIELDING : hr.helpNeeded,
+        HelpNeededSubtype: hr.helpNeededSubtype,
         HelpWithAccessingFood: hr.helpWithAccessingFood,
         HelpWithAccessingSupermarketFood: hr.helpWithAccessingSupermarketFood,
         HelpWithCompletingNssForm: hr.helpWithCompletingNssForm,

--- a/src/pages/add-support/[residentId]/index.js
+++ b/src/pages/add-support/[residentId]/index.js
@@ -1,206 +1,258 @@
-import CallbackForm from "../../../components/CallbackForm/CallbackForm";
-import Layout from "../../../components/layout";
-import Link from "next/link";
-import KeyInformation from "../../../components/KeyInformation/KeyInformation";
-import {ResidentGateway} from "../../../gateways/resident";
-import {unsafeExtractUser} from "../../../helpers/auth";
-import React, { useEffect, useState } from "react";
-import {HelpRequestGateway} from "../../../gateways/help-request";
-import {HelpRequestCallGateway} from "../../../gateways/help-request-call";
-import {CaseNotesGateway} from "../../../gateways/case-notes";
-import {useRouter} from "next/router";
-import {GovNotifyGateway} from '../../../gateways/gov-notify'
-import { TEST_AND_TRACE_FOLLOWUP_EMAIL, TEST_AND_TRACE_FOLLOWUP_TEXT } from "../../../helpers/constants";
-import getTimeZoneCorrectedLocalDate from "../../../../tools/etcUtility"
+import CallbackForm from '../../../components/CallbackForm/CallbackForm';
+import Layout from '../../../components/layout';
+import Link from 'next/link';
+import KeyInformation from '../../../components/KeyInformation/KeyInformation';
+import { ResidentGateway } from '../../../gateways/resident';
+import { unsafeExtractUser } from '../../../helpers/auth';
+import React, { useEffect, useState } from 'react';
+import { HelpRequestGateway } from '../../../gateways/help-request';
+import { HelpRequestCallGateway } from '../../../gateways/help-request-call';
+import { CaseNotesGateway } from '../../../gateways/case-notes';
+import { useRouter } from 'next/router';
+import { GovNotifyGateway } from '../../../gateways/gov-notify';
+import {
+    TEST_AND_TRACE_FOLLOWUP_EMAIL,
+    TEST_AND_TRACE_FOLLOWUP_TEXT
+} from '../../../helpers/constants';
+import getTimeZoneCorrectedLocalDate from '../../../../tools/etcUtility';
 
-export default function addSupportPage({residentId}) {
-	const backHref = `/helpcase-profile/${residentId}`;
+export default function addSupportPage({ residentId }) {
+    const backHref = `/helpcase-profile/${residentId}`;
 
-	const [resident, setResident] = useState({});
-	const [user, setUser] = useState({});
+    const [resident, setResident] = useState({});
+    const [user, setUser] = useState({});
 
-	const router = useRouter();
+    const router = useRouter();
 
-	const retreiveResidentAndUser = async ( ) => {
-		const gateway = new ResidentGateway();
-		const resident = await gateway.getResident(residentId);
-		setResident(resident)
-		const user = unsafeExtractUser()
-		setUser(user)
-	}
+    const retreiveResidentAndUser = async () => {
+        const gateway = new ResidentGateway();
+        const resident = await gateway.getResident(residentId);
+        setResident(resident);
+        const user = unsafeExtractUser();
+        setUser(user);
+    };
 
-	useEffect(async () => {
-		await retreiveResidentAndUser()
-	}, []);
+    useEffect(async () => {
+        await retreiveResidentAndUser();
+    }, []);
 
-	const saveFunction = async function(helpNeeded, callDirection, callOutcomeValues, helpRequestObject, callMade, caseNote, phoneNumber, email) {
-		let callRequestObject = {
-			callType: helpNeeded,
-			callDirection: callDirection,
-			callOutcome: callOutcomeValues,
-			callDateTime: getTimeZoneCorrectedLocalDate(),
-			callHandler: user.name
-		}
+    const saveFunction = async function (
+        helpNeeded,
+        helpNeededSubtype,
+        callDirection,
+        callOutcomeValues,
+        helpRequestObject,
+        callMade,
+        caseNote,
+        phoneNumber,
+        email
+    ) {
+        let callRequestObject = {
+            callType: helpNeeded,
+            callSubType: helpNeededSubtype,
+            callDirection: callDirection,
+            callOutcome: callOutcomeValues,
+            callDateTime: getTimeZoneCorrectedLocalDate(),
+            callHandler: user.name
+        };
+        let errorHasHappened = false;
 
-		let errorHasHappened = false;
+        try {
+            let helpRequestGateway = new HelpRequestGateway();
+            const caseNotesGateway = new CaseNotesGateway();
+            let govNotifyGateway = new GovNotifyGateway();
 
-		try {
-			let helpRequestGateway = new HelpRequestGateway();
-			const caseNotesGateway = new CaseNotesGateway();
-			let govNotifyGateway = new GovNotifyGateway()
+            let helpRequestId = await helpRequestGateway
+                .postHelpRequest(residentId, helpRequestObject)
+                .catch((err) => {
+                    errorHasHappened = true;
+                    const hrPostFailure = "Error happened while POST'ing Help Request.";
+                    const nonEmptyHRObjectVals = Object.values(helpRequestObject).filter((v) => v)
+                        .length;
 
-			let helpRequestId = await helpRequestGateway.postHelpRequest(residentId, helpRequestObject)
-				.catch(err => {
-					errorHasHappened = true;
-					const hrPostFailure = "Error happened while POST'ing Help Request.";
-					const nonEmptyHRObjectVals = Object.values(helpRequestObject).filter(v => v).length;
+                    console.error(
+                        `${hrPostFailure}\nResId: ${residentId}, HRnonEmptyFieldsNum: ${nonEmptyHRObjectVals}\n${err}`
+                    );
+                    alert(hrPostFailure); // warning user about potential loss of data
+                });
 
-					console.error(`${hrPostFailure}\nResId: ${residentId}, HRnonEmptyFieldsNum: ${nonEmptyHRObjectVals}\n${err}`);
-					alert(hrPostFailure); // warning user about potential loss of data
-				});
+            if (callMade) {
+                let helpRequestCallGateway = new HelpRequestCallGateway();
+                await helpRequestCallGateway
+                    .postHelpRequestCall(helpRequestId, callRequestObject)
+                    .catch((err) => {
+                        errorHasHappened = true;
+                        const hrCallPostFailure =
+                            "Error happened while POST'ing Help Request Call.";
+                        const nonEmptyHRCallObjectVals = Object.values(callRequestObject).filter(
+                            (v) => v
+                        ).length;
 
-			if(callMade) {
-				let helpRequestCallGateway = new HelpRequestCallGateway()
-				await helpRequestCallGateway.postHelpRequestCall(helpRequestId, callRequestObject)
-					.catch(err => {
-						errorHasHappened = true;
-						const hrCallPostFailure = "Error happened while POST'ing Help Request Call.";
-						const nonEmptyHRCallObjectVals = Object.values(callRequestObject).filter(v => v).length;
-						
-						console.error(`${hrCallPostFailure}\nHelpReqId: ${helpRequestId}, HRCallnonEmptyFieldsNum: ${nonEmptyHRCallObjectVals}\n${err}`);
-						alert(hrCallPostFailure); // warning user about potential loss of data
-					});
-			}
+                        console.error(
+                            `${hrCallPostFailure}\nHelpReqId: ${helpRequestId}, HRCallnonEmptyFieldsNum: ${nonEmptyHRCallObjectVals}\n${err}`
+                        );
+                        alert(hrCallPostFailure); // warning user about potential loss of data
+                    });
+            }
 
-			if (caseNote && caseNote != "") {
-				const caseNoteObject = {
-						caseNote,
-						author: user.name,
-						noteDate: new Date().toGMTString(),
-						helpNeeded: helpNeeded
-				};      
-				await caseNotesGateway.createCaseNote(helpRequestId, residentId, caseNoteObject)
-					.catch(err => {
-						errorHasHappened = true;
-						const hrCNPostFailure = "Error happened while POST'ing Help Request Case Note.";
-						const nonEmptyHRCNObjectVals = Object.values(caseNoteObject).filter(v => v).length;
-						
-						console.error(`${hrCNPostFailure}\nResId: ${residentId}, HelpReqId: ${helpRequestId}, HRCNnonEmptyFieldsNum: ${nonEmptyHRCNObjectVals}\n${err}`);
-						alert(hrCNPostFailure); // warning user about potential loss of data
-					});
-			}
+            if (caseNote && caseNote != '') {
+                const caseNoteObject = {
+                    caseNote,
+                    author: user.name,
+                    noteDate: new Date().toGMTString(),
+                    helpNeeded: helpNeeded
+                };
+                await caseNotesGateway
+                    .createCaseNote(helpRequestId, residentId, caseNoteObject)
+                    .catch((err) => {
+                        errorHasHappened = true;
+                        const hrCNPostFailure =
+                            "Error happened while POST'ing Help Request Case Note.";
+                        const nonEmptyHRCNObjectVals = Object.values(caseNoteObject).filter(
+                            (v) => v
+                        ).length;
 
-			if(phoneNumber){
-				let textResponse = await govNotifyGateway.sendText(phoneNumber, TEST_AND_TRACE_FOLLOWUP_TEXT)
-					.catch(err => {
-						errorHasHappened = true;
-						const smsFailure = "Error happened while sending a text message.";
-						
-						console.error(`${smsFailure}\nPhoneNumber: ${phoneNumber}\n${err}`);
-						alert(smsFailure); // warning user about potential loss of data
-					});
+                        console.error(
+                            `${hrCNPostFailure}\nResId: ${residentId}, HelpReqId: ${helpRequestId}, HRCNnonEmptyFieldsNum: ${nonEmptyHRCNObjectVals}\n${err}`
+                        );
+                        alert(hrCNPostFailure); // warning user about potential loss of data
+                    });
+            }
 
-				let sendTextResponseCaseNoteObject;
-				if(textResponse.id){
-						sendTextResponseCaseNoteObject = {
-								caseNote: `Text sent to ${phoneNumber}. \n Text id: ${textResponse.id}.\n Text content: ${textResponse.content.body}`,
-								author: user.name,
-								noteDate: new Date().toGMTString(),
-								helpNeeded: helpRequestObject.helpNeeded 
-						}
-				}else{
-						sendTextResponseCaseNoteObject ={
-								caseNote: `Failed text to ${phoneNumber}`,
-								author: user.name,
-								noteDate: new Date().toGMTString(),
-								helpNeeded: helpRequestObject.helpNeeded 
-						}
-				}
+            if (phoneNumber) {
+                let textResponse = await govNotifyGateway
+                    .sendText(phoneNumber, TEST_AND_TRACE_FOLLOWUP_TEXT)
+                    .catch((err) => {
+                        errorHasHappened = true;
+                        const smsFailure = 'Error happened while sending a text message.';
 
-				await caseNotesGateway.createCaseNote(helpRequestId, residentId, sendTextResponseCaseNoteObject)
-					.catch(err => {
-						errorHasHappened = true;
-						const hrCNPostFailure = "Error happened while POST'ing Text Confirmation Help Request Case Note.";
-						const nonEmptyTextRespObjectVals = Object.values(sendTextResponseCaseNoteObject).filter(v => v).length;
-						
-						console.error(`${hrCNPostFailure}\nResId: ${residentId}, HelpReqId: ${helpRequestId}, TextRespnonEmptyFieldsNum: ${nonEmptyTextRespObjectVals}\n${err}`);
-						alert(hrCNPostFailure); // warning user about potential loss of data
-					});
-			}
+                        console.error(`${smsFailure}\nPhoneNumber: ${phoneNumber}\n${err}`);
+                        alert(smsFailure); // warning user about potential loss of data
+                    });
 
-			if(email){
-				let emailResponse = await govNotifyGateway.sendEmail(email, TEST_AND_TRACE_FOLLOWUP_EMAIL)
-					.catch(err => {
-						errorHasHappened = true;
-						const emailFailure = "Error happened while sending an email.";
-						
-						console.error(`${emailFailure}\nEmail: ${email}\n${err}`);
-						alert(emailFailure); // warning user about potential loss of data
-					});
-					
-				let sendEmailResponseCaseNoteObject;
+                let sendTextResponseCaseNoteObject;
+                if (textResponse.id) {
+                    sendTextResponseCaseNoteObject = {
+                        caseNote: `Text sent to ${phoneNumber}. \n Text id: ${textResponse.id}.\n Text content: ${textResponse.content.body}`,
+                        author: user.name,
+                        noteDate: new Date().toGMTString(),
+                        helpNeeded: helpRequestObject.helpNeeded
+                    };
+                } else {
+                    sendTextResponseCaseNoteObject = {
+                        caseNote: `Failed text to ${phoneNumber}`,
+                        author: user.name,
+                        noteDate: new Date().toGMTString(),
+                        helpNeeded: helpRequestObject.helpNeeded
+                    };
+                }
 
-				if(emailResponse.id){
-						sendEmailResponseCaseNoteObject = {
-								caseNote: `Email sent to ${email}. Email id: ${emailResponse.id}. Email content: ${emailResponse.content.body}`,
-								author: user.name,
-								noteDate: new Date().toGMTString(),
-								helpNeeded: helpRequestObject.helpNeeded 
-						}
-				}else{
-						sendEmailResponseCaseNoteObject ={
-								caseNote: `Failed email to ${email}`,
-								author: user.name,
-								noteDate: new Date().toGMTString(),
-								helpNeeded: helpRequestObject.helpNeeded 
-						}
-				}
-				await caseNotesGateway.createCaseNote(helpRequestId, residentId, sendEmailResponseCaseNoteObject)
-					.catch(err => {
-						errorHasHappened = true;
-						const hrCNPostFailure = "Error happened while POST'ing Email Confirmation Help Request Case Note.";
-						const nonEmptyEmailRespObjectVals = Object.values(sendEmailResponseCaseNoteObject).filter(v => v).length;
-						
-						console.error(`${hrCNPostFailure}\nResId: ${residentId}, HelpReqId: ${helpRequestId}, EmailRespnonEmptyFieldsNum: ${nonEmptyEmailRespObjectVals}\n${err}`);
-						alert(hrCNPostFailure); // warning user about potential loss of data
-					});
-			}
+                await caseNotesGateway
+                    .createCaseNote(helpRequestId, residentId, sendTextResponseCaseNoteObject)
+                    .catch((err) => {
+                        errorHasHappened = true;
+                        const hrCNPostFailure =
+                            "Error happened while POST'ing Text Confirmation Help Request Case Note.";
+                        const nonEmptyTextRespObjectVals = Object.values(
+                            sendTextResponseCaseNoteObject
+                        ).filter((v) => v).length;
 
-			if (!errorHasHappened) {
-				router.push(`/helpcase-profile/${residentId}`);
-			}
-		} catch (err) {
-			// Other errors. 
-			console.log("Add support error", err)
-			alert('An error has occured while saving the data.');
-		}
-	}
+                        console.error(
+                            `${hrCNPostFailure}\nResId: ${residentId}, HelpReqId: ${helpRequestId}, TextRespnonEmptyFieldsNum: ${nonEmptyTextRespObjectVals}\n${err}`
+                        );
+                        alert(hrCNPostFailure); // warning user about potential loss of data
+                    });
+            }
 
-	return (
-		<Layout>
-			<div>
-				<Link href={backHref}>
-					<a href="#" className="govuk-back-link">Back</a>
-				</Link>
-				<div className="govuk-grid-row">
-					<div className="govuk-grid-column-one-quarter-from-desktop">
-						<KeyInformation resident={resident}/>
-					</div>
-					<div className="govuk-grid-column-three-quarters-from-desktop">
-						<CallbackForm residentId={residentId} resident={resident} backHref={backHref} saveFunction={saveFunction} editableCaseNotes={true} helpRequestExists={false} />
-					</div>
-				</div>
-			</div>
-		</Layout>
-	);
+            if (email) {
+                let emailResponse = await govNotifyGateway
+                    .sendEmail(email, TEST_AND_TRACE_FOLLOWUP_EMAIL)
+                    .catch((err) => {
+                        errorHasHappened = true;
+                        const emailFailure = 'Error happened while sending an email.';
+
+                        console.error(`${emailFailure}\nEmail: ${email}\n${err}`);
+                        alert(emailFailure); // warning user about potential loss of data
+                    });
+
+                let sendEmailResponseCaseNoteObject;
+
+                if (emailResponse.id) {
+                    sendEmailResponseCaseNoteObject = {
+                        caseNote: `Email sent to ${email}. Email id: ${emailResponse.id}. Email content: ${emailResponse.content.body}`,
+                        author: user.name,
+                        noteDate: new Date().toGMTString(),
+                        helpNeeded: helpRequestObject.helpNeeded
+                    };
+                } else {
+                    sendEmailResponseCaseNoteObject = {
+                        caseNote: `Failed email to ${email}`,
+                        author: user.name,
+                        noteDate: new Date().toGMTString(),
+                        helpNeeded: helpRequestObject.helpNeeded
+                    };
+                }
+                await caseNotesGateway
+                    .createCaseNote(helpRequestId, residentId, sendEmailResponseCaseNoteObject)
+                    .catch((err) => {
+                        errorHasHappened = true;
+                        const hrCNPostFailure =
+                            "Error happened while POST'ing Email Confirmation Help Request Case Note.";
+                        const nonEmptyEmailRespObjectVals = Object.values(
+                            sendEmailResponseCaseNoteObject
+                        ).filter((v) => v).length;
+
+                        console.error(
+                            `${hrCNPostFailure}\nResId: ${residentId}, HelpReqId: ${helpRequestId}, EmailRespnonEmptyFieldsNum: ${nonEmptyEmailRespObjectVals}\n${err}`
+                        );
+                        alert(hrCNPostFailure); // warning user about potential loss of data
+                    });
+            }
+
+            if (!errorHasHappened) {
+                router.push(`/helpcase-profile/${residentId}`);
+            }
+        } catch (err) {
+            // Other errors.
+            console.log('Add support error', err);
+            alert('An error has occured while saving the data.');
+        }
+    };
+
+    return (
+        <Layout>
+            <div>
+                <Link href={backHref}>
+                    <a href="#" className="govuk-back-link">
+                        Back
+                    </a>
+                </Link>
+                <div className="govuk-grid-row">
+                    <div className="govuk-grid-column-one-quarter-from-desktop">
+                        <KeyInformation resident={resident} />
+                    </div>
+                    <div className="govuk-grid-column-three-quarters-from-desktop">
+                        <CallbackForm
+                            residentId={residentId}
+                            resident={resident}
+                            backHref={backHref}
+                            saveFunction={saveFunction}
+                            editableCaseNotes={true}
+                            helpRequestExists={false}
+                        />
+                    </div>
+                </div>
+            </div>
+        </Layout>
+    );
 }
 
 addSupportPage.getInitialProps = async ({ query: { residentId }, req, res }) => {
-	try {
-		return {
-			residentId,
-		};
-	} catch (err) {
-		console.log(`Error getting resident props with help request ID ${residentId}: ${err}`);
-	}
+    try {
+        return {
+            residentId
+        };
+    } catch (err) {
+        console.log(`Error getting resident props with help request ID ${residentId}: ${err}`);
+    }
 };

--- a/src/pages/add-support/[residentId]/index.js
+++ b/src/pages/add-support/[residentId]/index.js
@@ -38,7 +38,6 @@ export default function addSupportPage({ residentId }) {
 
     const saveFunction = async function (
         helpNeeded,
-        helpNeededSubtype,
         callDirection,
         callOutcomeValues,
         helpRequestObject,
@@ -49,7 +48,6 @@ export default function addSupportPage({ residentId }) {
     ) {
         let callRequestObject = {
             callType: helpNeeded,
-            callSubType: helpNeededSubtype,
             callDirection: callDirection,
             callOutcome: callOutcomeValues,
             callDateTime: getTimeZoneCorrectedLocalDate(),


### PR DESCRIPTION
**What**
* Have added in the option to have a subtype on the help request screen, if a help type that has subtypes is selected (currently only Link Work falls into this category)
* Selecting a subtype is optional
* Have updated the test to test this

![image](https://user-images.githubusercontent.com/32848419/135302272-5fbc6a18-c178-4426-8770-dbe2485cac7a.png)

**Why**
* Link work requires the ability to have a subtype and this fix allows this to be done manually


**Anything Else**
https://github.com/LBHackney-IT/cv-19-res-support-v3/pull/135 should be deployed first to allow this to work
Existing files were formatted