### PR TITLE
Remove follow up email and text options for Link Work

### DIFF
--- a/cypress/integration/journeys/add-link-work.spec.js
+++ b/cypress/integration/journeys/add-link-work.spec.js
@@ -10,12 +10,14 @@ beforeEach(() => {
 });
 
 context('When adding new link work help request and call completed is selected', () => {
-    it('does not display self isolation help needs form and form can be submitted', () => {
+    it('does not display self isolation help needs form or follow up email or sms options and form can be submitted', () => {
         cy.get('[data-testid=call-type-radio-button]').eq(4).click({ force: true });
         cy.get('[data-testid=call-type-yes-radio-button]').click({ force: true });
         cy.get('[data-testid=yes-spoke-to-resident]').click({ force: true });
         cy.get('[data-testid=callback_complete-checkbox]').click({ force: true });
         cy.get('[data-testid=self-isolation-needs]').should('not.exist');
+        cy.get('[data-testid=send-text-checkbox]').should('not.exist');
+        cy.get('[data-testid=send-email-checkbox]').should('not.exist');
 
         cy.get('[data-testid=call-direction-radio-button]').first().click({ force: true });
         cy.get('[data-testid=followup-required-radio-button]').first().click({ force: true });

--- a/src/components/CallbackForm/CallbackForm.js
+++ b/src/components/CallbackForm/CallbackForm.js
@@ -8,6 +8,7 @@ import {
     TEST_AND_TRACE_FOLLOWUP_TEXT,
     TEST_AND_TRACE_FOLLOWUP_EMAIL,
     EUSS,
+    LINK_WORK,
     WELFARE_CALL
 } from '../../helpers/constants';
 import { formatSubText } from '../../helpers/formatter';
@@ -756,7 +757,7 @@ export default function CallbackForm({
                 )}
                 <br></br>
 
-                {helpNeeded !== EUSS && helpNeeded && (
+                {helpNeeded !== EUSS && helpNeeded !== LINK_WORK && helpNeeded && (
                     <fieldset className="govuk-fieldset">
                         <h3 className="govuk-heading-m">
                             Would you like to message the resident following this call?


### PR DESCRIPTION
**What**
* Remove the options for follow up email and follow up SMS from the add help request screen when Link Work is the selected help type
* Tests added for this

**Why**
* There is not yet custom messaging for the Link Work help type, and we don't want the default option to sent
