### PR TITLE
Authentication hotfix

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -14,13 +14,13 @@ Cypress.Commands.add('getBySel', (selector, ...args) => {
 export const defaultUser = {
     email: 'test@hackney.gov.uk',
     name: 'Test User',
-    groups: ['development-team-staging']
+    groups: ['inh-users-dev']
 };
 
 export const EUSS_User = {
     email: 'test@hackney.gov.uk',
     name: 'EUSS Test User',
-    groups: ['development-team-staging', EUSS_GROUP]
+    groups: ['inh-users-dev', EUSS_GROUP]
 };
 
 Cypress.Commands.add('login', (userData) => {

--- a/serverless.yml
+++ b/serverless.yml
@@ -38,7 +38,7 @@ functions:
     environment:
       APP_URL: https://${self:custom.aliases.${self:provider.stage}}
       APP_STAGE: ${self:provider.stage}
-      NEXT_PUBLIC_HACKNEY_GOOGLE_GROUP: inh-users-dev
+      NEXT_PUBLIC_HACKNEY_GOOGLE_GROUP: ${ssm:/here-to-help/${self:provider.stage}/access-google-group}
       NEXT_PUBLIC_HACKNEY_COOKIE_NAME: hackneyToken
       HACKNEY_JWT_SECRET: ${ssm:/common/hackney-jwt-secret}
       HERE_TO_HELP_API_BASE_URL: ${ssm:/cv-19-res-support-v3/${self:provider.stage}/api-base-url}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -8,8 +8,7 @@ import {
   pathIsWhitelisted,
   serverSideRedirect,
   unsafeExtractUser,
-  User,
-  userIsInValidGroup,
+  User
 } from '../helpers/auth';
 import { UserContext } from '../contexts/UserContext';
 import { NextPage } from 'next';

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,6 +4,7 @@ import App, { AppContext, AppProps } from 'next/app';
 import React from 'react';
 import {
   authoriseUser,
+  userIsInValidGroup,
   pathIsWhitelisted,
   serverSideRedirect,
   unsafeExtractUser,
@@ -55,11 +56,11 @@ CustomApp.getInitialProps = async (appContext) => {
 
     return { accessDenied: true };
   }
-  //
-  // if (!userIsInValidGroup(user)) {
-  //   console.warn('The user is not in the correct google group');
-  //   return { accessDenied: true };
-  // }
+  
+  if (!userIsInValidGroup(user)) {
+    console.warn('The user is not in the correct google group');
+    return { accessDenied: true };
+  }
 
   return props;
 };


### PR DESCRIPTION
# What:
 - Re-enabling of the Google Group restrictions upon authentication.
 - Replacing the hard-coded Google Group with a lookup within the AWS Parameter Store.
 - Modify automated test authentication intercepts to contain a group matching the environment sample file.

# Why:
 - The Google Group based restrictions were [removed](https://github.com/LBHackney-IT/coronavirus-here-to-help-frontend/commit/741aabe7aa880ae4bca04b525bc5f525d2fb0c25) by an accident due to an assumption that the authentication that Proxy does includes the checking of Google Groups _(which it did not)_.

# Notes:
 - The code is about to be tested on Staging environment to ensure the completeness of the PR.